### PR TITLE
Don't try and use name parts

### DIFF
--- a/dist/model/person-list.v1.json
+++ b/dist/model/person-list.v1.json
@@ -25,25 +25,27 @@
                                 "title": "Name",
                                 "type": "object",
                                 "properties": {
-                                    "givenNames": {
-                                        "title": "Given names",
+                                    "long": {
+                                        "title": "Long name",
+                                        "description": "This is generally the name that is used by the person for English-language publications.\n\nFor example:\n  - Randy Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                         "type": "string",
                                         "minLength": 1
                                     },
-                                    "surname": {
-                                        "title": "Surname",
+                                    "short": {
+                                        "title": "Short name",
+                                        "description": "This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.\n\nFor example:\n  - R. Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                         "type": "string",
                                         "minLength": 1
                                     },
-                                    "suffix": {
-                                        "title": "Suffix",
-                                        "type": "string",
-                                        "minLength": 1
+                                    "index": {
+                                        "title": "Index name",
+                                        "description": "This is the name that should be used for indexing people.\n\nFor example:\n  - Schekman, Randy\n  - VijayRaghavan, Krishnaswamy\n  - Wenhui Li\n"
                                     }
                                 },
                                 "required": [
-                                    "givenNames",
-                                    "surname"
+                                    "long",
+                                    "short",
+                                    "index"
                                 ]
                             },
                             "orcid": {

--- a/dist/model/person-list.v1.json
+++ b/dist/model/person-list.v1.json
@@ -25,15 +25,9 @@
                                 "title": "Name",
                                 "type": "object",
                                 "properties": {
-                                    "long": {
-                                        "title": "Long name",
+                                    "preferred": {
+                                        "title": "Preferred name",
                                         "description": "This is generally the name that is used by the person for English-language publications.\n\nFor example:\n  - Randy Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    "short": {
-                                        "title": "Short name",
-                                        "description": "This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.\n\nFor example:\n  - R. Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                         "type": "string",
                                         "minLength": 1
                                     },
@@ -43,8 +37,7 @@
                                     }
                                 },
                                 "required": [
-                                    "long",
-                                    "short",
+                                    "preferred",
                                     "index"
                                 ]
                             },

--- a/dist/model/person.v1.json
+++ b/dist/model/person.v1.json
@@ -17,15 +17,9 @@
                             "title": "Name",
                             "type": "object",
                             "properties": {
-                                "long": {
-                                    "title": "Long name",
+                                "preferred": {
+                                    "title": "Preferred name",
                                     "description": "This is generally the name that is used by the person for English-language publications.\n\nFor example:\n  - Randy Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                "short": {
-                                    "title": "Short name",
-                                    "description": "This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.\n\nFor example:\n  - R. Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                     "type": "string",
                                     "minLength": 1
                                 },
@@ -35,8 +29,7 @@
                                 }
                             },
                             "required": [
-                                "long",
-                                "short",
+                                "preferred",
                                 "index"
                             ]
                         },

--- a/dist/model/person.v1.json
+++ b/dist/model/person.v1.json
@@ -17,25 +17,27 @@
                             "title": "Name",
                             "type": "object",
                             "properties": {
-                                "givenNames": {
-                                    "title": "Given names",
+                                "long": {
+                                    "title": "Long name",
+                                    "description": "This is generally the name that is used by the person for English-language publications.\n\nFor example:\n  - Randy Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                     "type": "string",
                                     "minLength": 1
                                 },
-                                "surname": {
-                                    "title": "Surname",
+                                "short": {
+                                    "title": "Short name",
+                                    "description": "This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.\n\nFor example:\n  - R. Schekman\n  - K. VijayRaghavan\n  - Wenhui Li\n",
                                     "type": "string",
                                     "minLength": 1
                                 },
-                                "suffix": {
-                                    "title": "Suffix",
-                                    "type": "string",
-                                    "minLength": 1
+                                "index": {
+                                    "title": "Index name",
+                                    "description": "This is the name that should be used for indexing people.\n\nFor example:\n  - Schekman, Randy\n  - VijayRaghavan, Krishnaswamy\n  - Wenhui Li\n"
                                 }
                             },
                             "required": [
-                                "givenNames",
-                                "surname"
+                                "long",
+                                "short",
+                                "index"
                             ]
                         },
                         "orcid": {

--- a/dist/samples/person-list/v1/first-page.json
+++ b/dist/samples/person-list/v1/first-page.json
@@ -5,8 +5,7 @@
             "id": "rschekman",
             "type": "leadership",
             "name": {
-                "long": "Randy Schekman",
-                "short": "R. Schekman",
+                "preferred": "Randy Schekman",
                 "index": "Schekman, Randy"
             }
         },
@@ -14,8 +13,7 @@
             "id": "jsmith",
             "type": "senior-editor",
             "name": {
-                "long": "John Smith III",
-                "short": "J. Smith III",
+                "preferred": "John Smith III",
                 "index": "Smith, John, III"
             },
             "orcid": "0000-0002-1825-0097",

--- a/dist/samples/person-list/v1/first-page.json
+++ b/dist/samples/person-list/v1/first-page.json
@@ -5,17 +5,18 @@
             "id": "rschekman",
             "type": "leadership",
             "name": {
-                "givenNames": "Randy",
-                "surname": "Schekman"
+                "long": "Randy Schekman",
+                "short": "R. Schekman",
+                "index": "Schekman, Randy"
             }
         },
         {
             "id": "jsmith",
             "type": "senior-editor",
             "name": {
-                "givenNames": "John",
-                "surname": "Smith",
-                "suffix": "III"
+                "long": "John Smith III",
+                "short": "J. Smith III",
+                "index": "Smith, John, III"
             },
             "orcid": "0000-0002-1825-0097",
             "image": {

--- a/dist/samples/person/v1/complete.json
+++ b/dist/samples/person/v1/complete.json
@@ -2,9 +2,9 @@
     "id": "jsmith",
     "type": "senior-editor",
     "name": {
-        "givenNames": "John",
-        "surname": "Smith",
-        "suffix": "III"
+        "long": "John Smith III",
+        "short": "J. Smith III",
+        "index": "Smith, John, III"
     },
     "orcid": "0000-0002-1825-0097",
     "research": {

--- a/dist/samples/person/v1/complete.json
+++ b/dist/samples/person/v1/complete.json
@@ -2,8 +2,7 @@
     "id": "jsmith",
     "type": "senior-editor",
     "name": {
-        "long": "John Smith III",
-        "short": "J. Smith III",
+        "preferred": "John Smith III",
         "index": "Smith, John, III"
     },
     "orcid": "0000-0002-1825-0097",

--- a/dist/samples/person/v1/minimum.json
+++ b/dist/samples/person/v1/minimum.json
@@ -2,8 +2,7 @@
     "id": "rschekman",
     "type": "leadership",
     "name": {
-        "long": "Randy Schekman",
-        "short": "R. Schekman",
+        "preferred": "Randy Schekman",
         "index": "Schekman, Randy"
     }
 }

--- a/dist/samples/person/v1/minimum.json
+++ b/dist/samples/person/v1/minimum.json
@@ -2,7 +2,8 @@
     "id": "rschekman",
     "type": "leadership",
     "name": {
-        "givenNames": "Randy",
-        "surname": "Schekman"
+        "long": "Randy Schekman",
+        "short": "R. Schekman",
+        "index": "Schekman, Randy"
     }
 }

--- a/src/misc/person.v1.yaml
+++ b/src/misc/person.v1.yaml
@@ -6,24 +6,13 @@ properties:
         title: Name
         type: object
         properties:
-            long:
-                title: Long name
+            preferred:
+                title: Preferred name
                 description: |
                     This is generally the name that is used by the person for English-language publications.
 
                     For example:
                       - Randy Schekman
-                      - K. VijayRaghavan
-                      - Wenhui Li
-                type: string
-                minLength: 1
-            short:
-                title: Short name
-                description: |
-                    This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.
-
-                    For example:
-                      - R. Schekman
                       - K. VijayRaghavan
                       - Wenhui Li
                 type: string
@@ -38,8 +27,7 @@ properties:
                       - VijayRaghavan, Krishnaswamy
                       - Wenhui Li
         required:
-          - long
-          - short
+          - preferred
           - index
     orcid:
         title: ORCID

--- a/src/misc/person.v1.yaml
+++ b/src/misc/person.v1.yaml
@@ -6,21 +6,41 @@ properties:
         title: Name
         type: object
         properties:
-            givenNames:
-                title: Given names
+            long:
+                title: Long name
+                description: |
+                    This is generally the name that is used by the person for English-language publications.
+
+                    For example:
+                      - Randy Schekman
+                      - K. VijayRaghavan
+                      - Wenhui Li
                 type: string
                 minLength: 1
-            surname:
-                title: Surname
+            short:
+                title: Short name
+                description: |
+                    This is a shortend form of the that is used by the person for English-language publications. Often parts of the name will be replaced by initials. In some cases the name may not be shortened, as so this value is the same as `long`.
+
+                    For example:
+                      - R. Schekman
+                      - K. VijayRaghavan
+                      - Wenhui Li
                 type: string
                 minLength: 1
-            suffix:
-                title: Suffix
-                type: string
-                minLength: 1
+            index:
+                title: Index name
+                description: |
+                    This is the name that should be used for indexing people.
+
+                    For example:
+                      - Schekman, Randy
+                      - VijayRaghavan, Krishnaswamy
+                      - Wenhui Li
         required:
-          - givenNames
-          - surname
+          - long
+          - short
+          - index
     orcid:
         title: ORCID
         type: string

--- a/src/samples/person-list/v1/first-page.json
+++ b/src/samples/person-list/v1/first-page.json
@@ -5,8 +5,7 @@
             "id": "rschekman",
             "type": "leadership",
             "name": {
-                "long": "Randy Schekman",
-                "short": "R. Schekman",
+                "preferred": "Randy Schekman",
                 "index": "Schekman, Randy"
             }
         },
@@ -14,8 +13,7 @@
             "id": "jsmith",
             "type": "senior-editor",
             "name": {
-                "long": "John Smith III",
-                "short": "J. Smith III",
+                "preferred": "John Smith III",
                 "index": "Smith, John, III"
             },
             "orcid": "0000-0002-1825-0097",

--- a/src/samples/person-list/v1/first-page.json
+++ b/src/samples/person-list/v1/first-page.json
@@ -5,17 +5,18 @@
             "id": "rschekman",
             "type": "leadership",
             "name": {
-                "givenNames": "Randy",
-                "surname": "Schekman"
+                "long": "Randy Schekman",
+                "short": "R. Schekman",
+                "index": "Schekman, Randy"
             }
         },
         {
             "id": "jsmith",
             "type": "senior-editor",
             "name": {
-                "givenNames": "John",
-                "surname": "Smith",
-                "suffix": "III"
+                "long": "John Smith III",
+                "short": "J. Smith III",
+                "index": "Smith, John, III"
             },
             "orcid": "0000-0002-1825-0097",
             "image": {

--- a/src/samples/person/v1/complete.json
+++ b/src/samples/person/v1/complete.json
@@ -2,9 +2,9 @@
     "id": "jsmith",
     "type": "senior-editor",
     "name": {
-        "givenNames": "John",
-        "surname": "Smith",
-        "suffix": "III"
+        "long": "John Smith III",
+        "short": "J. Smith III",
+        "index": "Smith, John, III"
     },
     "orcid": "0000-0002-1825-0097",
     "research": {

--- a/src/samples/person/v1/complete.json
+++ b/src/samples/person/v1/complete.json
@@ -2,8 +2,7 @@
     "id": "jsmith",
     "type": "senior-editor",
     "name": {
-        "long": "John Smith III",
-        "short": "J. Smith III",
+        "preferred": "John Smith III",
         "index": "Smith, John, III"
     },
     "orcid": "0000-0002-1825-0097",

--- a/src/samples/person/v1/minimum.json
+++ b/src/samples/person/v1/minimum.json
@@ -2,8 +2,7 @@
     "id": "rschekman",
     "type": "leadership",
     "name": {
-        "long": "Randy Schekman",
-        "short": "R. Schekman",
+        "preferred": "Randy Schekman",
         "index": "Schekman, Randy"
     }
 }

--- a/src/samples/person/v1/minimum.json
+++ b/src/samples/person/v1/minimum.json
@@ -2,7 +2,8 @@
     "id": "rschekman",
     "type": "leadership",
     "name": {
-        "givenNames": "Randy",
-        "surname": "Schekman"
+        "long": "Randy Schekman",
+        "short": "R. Schekman",
+        "index": "Schekman, Randy"
     }
 }


### PR DESCRIPTION
As we know, [names are hard](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/). Recently we've had a case of an author without a (possibly-known) given name.

So, I think we should avoid trying to use named parts of names (as that's near impossible to get right), and instead use a few basic forms. I propose 'long' (note this is different to 'full') and 'short', and also include an 'index' form for sorting.
