### PR TITLE
Separate block type list

### DIFF
--- a/dist/model/blog-article.v1.json
+++ b/dist/model/blog-article.v1.json
@@ -50,122 +50,180 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Blockquote",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "blockquote"
-                                        ]
-                                    },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    },
-                                    "citation": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Image",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "image"
-                                        ]
-                                    },
-                                    "alt": {
-                                        "title": "Alternative text",
-                                        "type": "string"
-                                    },
-                                    "uri": {
-                                        "title": "Image URI",
-                                        "type": "string",
-                                        "format": "uri",
-                                        "pattern": "^https://"
-                                    },
-                                    "caption": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "alt",
-                                    "uri"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Section",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "list"
-                                        ]
-                                    },
-                                    "ordered": {
-                                        "type": "boolean"
-                                    },
-                                    "items": {
-                                        "description": "List items",
-                                        "type": "array",
-                                        "items": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                }
-                                            ]
+                                "oneOf": [
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Blockquote",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "blockquote"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            },
+                                            "citation": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
                                         },
-                                        "minItems": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "items"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Paragraph",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "paragraph"
+                                        "required": [
+                                            "type",
+                                            "text"
                                         ]
                                     },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "image"
+                                                ]
+                                            },
+                                            "alt": {
+                                                "title": "Alternative text",
+                                                "type": "string"
+                                            },
+                                            "uri": {
+                                                "title": "Image URI",
+                                                "type": "string",
+                                                "format": "uri",
+                                                "pattern": "^https://"
+                                            },
+                                            "caption": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "alt",
+                                            "uri"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Section",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "list"
+                                                ]
+                                            },
+                                            "ordered": {
+                                                "type": "boolean"
+                                            },
+                                            "items": {
+                                                "description": "List items",
+                                                "type": "array",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/1"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/2"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/3"
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "items"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Paragraph",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "paragraph"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "text"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Table",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "table"
+                                                ]
+                                            },
+                                            "html": {
+                                                "title": "HTML table",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "html"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "YouTube video",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "youtube"
+                                                ]
+                                            },
+                                            "id": {
+                                                "title": "Video ID",
+                                                "type": "string"
+                                            },
+                                            "width": {
+                                                "title": "Width",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "height": {
+                                                "title": "Height",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "id",
+                                            "width",
+                                            "height"
+                                        ]
                                     }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
                                 ]
                             },
                             {
@@ -187,29 +245,7 @@
                                         "description": "Content",
                                         "type": "array",
                                         "items": {
-                                            "oneOf": [
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/0"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/4"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/5"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/6"
-                                                }
-                                            ]
+                                            "$ref": "#/allOf/1/properties/content/items"
                                         },
                                         "minItems": 1
                                     }
@@ -218,60 +254,6 @@
                                     "type",
                                     "title",
                                     "content"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Table",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "table"
-                                        ]
-                                    },
-                                    "html": {
-                                        "title": "HTML table",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "html"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "YouTube video",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "youtube"
-                                        ]
-                                    },
-                                    "id": {
-                                        "title": "Video ID",
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "title": "Width",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    },
-                                    "height": {
-                                        "title": "Height",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "id",
-                                    "width",
-                                    "height"
                                 ]
                             }
                         ]

--- a/dist/model/event.v1.json
+++ b/dist/model/event.v1.json
@@ -52,122 +52,180 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Blockquote",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "blockquote"
-                                        ]
-                                    },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    },
-                                    "citation": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Image",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "image"
-                                        ]
-                                    },
-                                    "alt": {
-                                        "title": "Alternative text",
-                                        "type": "string"
-                                    },
-                                    "uri": {
-                                        "title": "Image URI",
-                                        "type": "string",
-                                        "format": "uri",
-                                        "pattern": "^https://"
-                                    },
-                                    "caption": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "alt",
-                                    "uri"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Section",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "list"
-                                        ]
-                                    },
-                                    "ordered": {
-                                        "type": "boolean"
-                                    },
-                                    "items": {
-                                        "description": "List items",
-                                        "type": "array",
-                                        "items": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                }
-                                            ]
+                                "oneOf": [
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Blockquote",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "blockquote"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            },
+                                            "citation": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
                                         },
-                                        "minItems": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "items"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Paragraph",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "paragraph"
+                                        "required": [
+                                            "type",
+                                            "text"
                                         ]
                                     },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "image"
+                                                ]
+                                            },
+                                            "alt": {
+                                                "title": "Alternative text",
+                                                "type": "string"
+                                            },
+                                            "uri": {
+                                                "title": "Image URI",
+                                                "type": "string",
+                                                "format": "uri",
+                                                "pattern": "^https://"
+                                            },
+                                            "caption": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "alt",
+                                            "uri"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Section",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "list"
+                                                ]
+                                            },
+                                            "ordered": {
+                                                "type": "boolean"
+                                            },
+                                            "items": {
+                                                "description": "List items",
+                                                "type": "array",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/1"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/2"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/3"
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "items"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Paragraph",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "paragraph"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "text"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Table",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "table"
+                                                ]
+                                            },
+                                            "html": {
+                                                "title": "HTML table",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "html"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "YouTube video",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "youtube"
+                                                ]
+                                            },
+                                            "id": {
+                                                "title": "Video ID",
+                                                "type": "string"
+                                            },
+                                            "width": {
+                                                "title": "Width",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "height": {
+                                                "title": "Height",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "id",
+                                            "width",
+                                            "height"
+                                        ]
                                     }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
                                 ]
                             },
                             {
@@ -189,29 +247,7 @@
                                         "description": "Content",
                                         "type": "array",
                                         "items": {
-                                            "oneOf": [
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/0"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/4"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/5"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/6"
-                                                }
-                                            ]
+                                            "$ref": "#/allOf/1/properties/content/items"
                                         },
                                         "minItems": 1
                                     }
@@ -220,60 +256,6 @@
                                     "type",
                                     "title",
                                     "content"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Table",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "table"
-                                        ]
-                                    },
-                                    "html": {
-                                        "title": "HTML table",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "html"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "YouTube video",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "youtube"
-                                        ]
-                                    },
-                                    "id": {
-                                        "title": "Video ID",
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "title": "Width",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    },
-                                    "height": {
-                                        "title": "Height",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "id",
-                                    "width",
-                                    "height"
                                 ]
                             }
                         ]

--- a/dist/model/labs-experiment.v1.json
+++ b/dist/model/labs-experiment.v1.json
@@ -131,122 +131,180 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Blockquote",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "blockquote"
-                                        ]
-                                    },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    },
-                                    "citation": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Image",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "image"
-                                        ]
-                                    },
-                                    "alt": {
-                                        "title": "Alternative text",
-                                        "type": "string"
-                                    },
-                                    "uri": {
-                                        "title": "Image URI",
-                                        "type": "string",
-                                        "format": "uri",
-                                        "pattern": "^https://"
-                                    },
-                                    "caption": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "alt",
-                                    "uri"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Section",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "list"
-                                        ]
-                                    },
-                                    "ordered": {
-                                        "type": "boolean"
-                                    },
-                                    "items": {
-                                        "description": "List items",
-                                        "type": "array",
-                                        "items": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                }
-                                            ]
+                                "oneOf": [
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Blockquote",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "blockquote"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            },
+                                            "citation": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
                                         },
-                                        "minItems": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "items"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Paragraph",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "paragraph"
+                                        "required": [
+                                            "type",
+                                            "text"
                                         ]
                                     },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "image"
+                                                ]
+                                            },
+                                            "alt": {
+                                                "title": "Alternative text",
+                                                "type": "string"
+                                            },
+                                            "uri": {
+                                                "title": "Image URI",
+                                                "type": "string",
+                                                "format": "uri",
+                                                "pattern": "^https://"
+                                            },
+                                            "caption": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "alt",
+                                            "uri"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Section",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "list"
+                                                ]
+                                            },
+                                            "ordered": {
+                                                "type": "boolean"
+                                            },
+                                            "items": {
+                                                "description": "List items",
+                                                "type": "array",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/1"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/2"
+                                                        },
+                                                        {
+                                                            "$ref": "#/allOf/1/properties/content/items/oneOf/0/oneOf/3"
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "items"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Paragraph",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "paragraph"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "text"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Table",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "table"
+                                                ]
+                                            },
+                                            "html": {
+                                                "title": "HTML table",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "html"
+                                        ]
+                                    },
+                                    {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "YouTube video",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "youtube"
+                                                ]
+                                            },
+                                            "id": {
+                                                "title": "Video ID",
+                                                "type": "string"
+                                            },
+                                            "width": {
+                                                "title": "Width",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "height": {
+                                                "title": "Height",
+                                                "type": "integer",
+                                                "minimum": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "id",
+                                            "width",
+                                            "height"
+                                        ]
                                     }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
                                 ]
                             },
                             {
@@ -268,29 +326,7 @@
                                         "description": "Content",
                                         "type": "array",
                                         "items": {
-                                            "oneOf": [
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/0"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/1"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/2"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/3"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/4"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/5"
-                                                },
-                                                {
-                                                    "$ref": "#/allOf/1/properties/content/items/oneOf/6"
-                                                }
-                                            ]
+                                            "$ref": "#/allOf/1/properties/content/items"
                                         },
                                         "minItems": 1
                                     }
@@ -299,60 +335,6 @@
                                     "type",
                                     "title",
                                     "content"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Table",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "table"
-                                        ]
-                                    },
-                                    "html": {
-                                        "title": "HTML table",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "html"
-                                ]
-                            },
-                            {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "YouTube video",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "youtube"
-                                        ]
-                                    },
-                                    "id": {
-                                        "title": "Video ID",
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "title": "Width",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    },
-                                    "height": {
-                                        "title": "Height",
-                                        "type": "integer",
-                                        "minimum": 1
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "id",
-                                    "width",
-                                    "height"
                                 ]
                             }
                         ]

--- a/src/blocks/section.v1.yaml
+++ b/src/blocks/section.v1.yaml
@@ -13,14 +13,7 @@ properties:
         description: Content
         type: array
         items:
-            oneOf:
-              - $ref: blockquote.v1.yaml
-              - $ref: image.v1.yaml
-              - $ref: list.v1.yaml
-              - $ref: paragraph.v1.yaml
-              - $ref: section.v1.yaml
-              - $ref: table.v1.yaml
-              - $ref: youtube.v1.yaml
+            $ref: ../misc/blocks-all.v1.yaml
         minItems: 1
 required:
   - type

--- a/src/misc/blocks-all.v1.yaml
+++ b/src/misc/blocks-all.v1.yaml
@@ -1,0 +1,3 @@
+oneOf:
+  - $ref: blocks-no-section.v1.yaml
+  - $ref: ../blocks/section.v1.yaml

--- a/src/misc/blocks-no-section.v1.yaml
+++ b/src/misc/blocks-no-section.v1.yaml
@@ -1,0 +1,7 @@
+oneOf:
+  - $ref: ../blocks/blockquote.v1.yaml
+  - $ref: ../blocks/image.v1.yaml
+  - $ref: ../blocks/list.v1.yaml
+  - $ref: ../blocks/paragraph.v1.yaml
+  - $ref: ../blocks/table.v1.yaml
+  - $ref: ../blocks/youtube.v1.yaml

--- a/src/model/blog-article.v1.yaml
+++ b/src/model/blog-article.v1.yaml
@@ -8,14 +8,7 @@ allOf:
             description: Content
             type: array
             items:
-                oneOf:
-                  - $ref: ../blocks/blockquote.v1.yaml
-                  - $ref: ../blocks/image.v1.yaml
-                  - $ref: ../blocks/list.v1.yaml
-                  - $ref: ../blocks/paragraph.v1.yaml
-                  - $ref: ../blocks/section.v1.yaml
-                  - $ref: ../blocks/table.v1.yaml
-                  - $ref: ../blocks/youtube.v1.yaml
+                $ref: ../misc/blocks-all.v1.yaml
             minItems: 1
     required:
       - content

--- a/src/model/event.v1.yaml
+++ b/src/model/event.v1.yaml
@@ -8,14 +8,7 @@ allOf:
             description: Content
             type: array
             items:
-                oneOf:
-                  - $ref: ../blocks/blockquote.v1.yaml
-                  - $ref: ../blocks/image.v1.yaml
-                  - $ref: ../blocks/list.v1.yaml
-                  - $ref: ../blocks/paragraph.v1.yaml
-                  - $ref: ../blocks/section.v1.yaml
-                  - $ref: ../blocks/table.v1.yaml
-                  - $ref: ../blocks/youtube.v1.yaml
+                $ref: ../misc/blocks-all.v1.yaml
             minItems: 1
         venue:
             $ref: ../misc/place.v1.yaml

--- a/src/model/labs-experiment.v1.yaml
+++ b/src/model/labs-experiment.v1.yaml
@@ -8,14 +8,7 @@ allOf:
             description: Content
             type: array
             items:
-                oneOf:
-                  - $ref: ../blocks/blockquote.v1.yaml
-                  - $ref: ../blocks/image.v1.yaml
-                  - $ref: ../blocks/list.v1.yaml
-                  - $ref: ../blocks/paragraph.v1.yaml
-                  - $ref: ../blocks/section.v1.yaml
-                  - $ref: ../blocks/table.v1.yaml
-                  - $ref: ../blocks/youtube.v1.yaml
+                $ref: ../misc/blocks-all.v1.yaml
             minItems: 1
     required:
       - content


### PR DESCRIPTION
To avoid not including a particular block type in a content type (eg the body of a blog article), I've abstract the list to two separate files, one that contains all block types and one that contains all types except for sections.
