### PR TITLE
Add article status everywhere

### DIFF
--- a/dist/api.raml
+++ b/dist/api.raml
@@ -301,7 +301,7 @@ traits:
                                             value: !include samples/article-poa/v1/minimum.json
                                         complete:
                                             displayName: Complete
-                                            value: !include samples/article-vor/v1/complete.json
+                                            value: !include samples/article-poa/v1/complete.json
                                 application/vnd.elife.article-vor+json;version=1:
                                     schema: !include model/article-vor.v1.json
                                     examples:

--- a/dist/model/article-list.v1.json
+++ b/dist/model/article-list.v1.json
@@ -11,284 +11,272 @@
         "items": {
             "title": "Articles",
             "type": "array",
-            "items": {
-                "allOf": [
-                    {
-                        "type": "object",
-                        "required": [
-                            "status"
-                        ]
-                    },
-                    {
-                        "oneOf": [
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "status": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "poa"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Article PoA snippet",
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "version": {
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "correction",
-                                                    "editorial",
-                                                    "feature",
-                                                    "insight",
-                                                    "research-advance",
-                                                    "research-article",
-                                                    "research-exchange",
-                                                    "retraction",
-                                                    "registered-report",
-                                                    "replication-study",
-                                                    "short-report",
-                                                    "tools-resources"
-                                                ]
-                                            },
-                                            "doi": {
-                                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                                "title": "DOI",
-                                                "type": "string",
-                                                "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
-                                            },
-                                            "title": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "published": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "volume": {
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "elocationId": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "pdf": {
-                                                "type": "string",
-                                                "format": "uri"
-                                            },
-                                            "subjects": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "researchOrganisms": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "relatedArticles": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "abstract": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "doi": {
-                                                        "$ref": "#/properties/items/items/allOf/1/oneOf/0/allOf/1/properties/doi"
-                                                    },
-                                                    "content": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "$schema": "http://json-schema.org/draft-04/schema#",
-                                                            "title": "Paragraph",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "paragraph"
-                                                                    ]
-                                                                },
-                                                                "text": {
-                                                                    "title": "Text",
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type",
-                                                                "text"
-                                                            ]
-                                                        },
-                                                        "minItems": 1
-                                                    }
-                                                },
-                                                "required": [
-                                                    "doi",
-                                                    "content"
-                                                ]
-                                            }
+            "items": [
+                {
+                    "oneOf": [
+                        {
+                            "$schema": "http://json-schema.org/draft-04/schema#",
+                            "title": "Article PoA snippet",
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$schema": "http://json-schema.org/draft-04/schema#",
+                                    "title": "Article snippet",
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "minLength": 1
                                         },
-                                        "required": [
-                                            "id",
-                                            "version",
-                                            "type",
-                                            "doi",
-                                            "title",
-                                            "published",
-                                            "volume",
-                                            "elocationId"
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "status": {
+                                        "version": {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "correction",
+                                                "editorial",
+                                                "feature",
+                                                "insight",
+                                                "research-advance",
+                                                "research-article",
+                                                "research-exchange",
+                                                "retraction",
+                                                "registered-report",
+                                                "replication-study",
+                                                "short-report",
+                                                "tools-resources"
+                                            ]
+                                        },
+                                        "doi": {
+                                            "$schema": "http://json-schema.org/draft-04/schema#",
+                                            "title": "DOI",
+                                            "type": "string",
+                                            "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
+                                        },
+                                        "title": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "published": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "volume": {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        "elocationId": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "pdf": {
+                                            "type": "string",
+                                            "format": "uri"
+                                        },
+                                        "subjects": {
+                                            "type": "array",
+                                            "items": {
                                                 "type": "string",
-                                                "enum": [
-                                                    "vor"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Article VoR snippet",
-                                        "type": "object",
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/properties/items/items/allOf/1/oneOf/0/allOf/1"
+                                                "minLength": 1
                                             },
-                                            {
-                                                "properties": {
-                                                    "impactStatement": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "image": {
+                                            "uniqueItems": true
+                                        },
+                                        "researchOrganisms": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            },
+                                            "uniqueItems": true
+                                        },
+                                        "relatedArticles": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            },
+                                            "uniqueItems": true
+                                        },
+                                        "abstract": {
+                                            "type": "object",
+                                            "properties": {
+                                                "doi": {
+                                                    "$ref": "#/properties/items/items/0/oneOf/0/allOf/0/properties/doi"
+                                                },
+                                                "content": {
+                                                    "type": "array",
+                                                    "items": {
                                                         "$schema": "http://json-schema.org/draft-04/schema#",
-                                                        "title": "Image",
+                                                        "title": "Paragraph",
                                                         "type": "object",
                                                         "properties": {
-                                                            "alt": {
-                                                                "title": "Alternative text",
-                                                                "type": "string"
-                                                            },
-                                                            "sizes": {
-                                                                "title": "Sizes",
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "2:1": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "900": {
-                                                                                "title": "2:1 crop at 900px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            },
-                                                                            "1800": {
-                                                                                "title": "2:1 crop at 1800px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "900",
-                                                                            "1800"
-                                                                        ]
-                                                                    },
-                                                                    "16:9": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "250": {
-                                                                                "title": "16:9 crop at 250px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            },
-                                                                            "500": {
-                                                                                "title": "16:9 crop at 500px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "250",
-                                                                            "500"
-                                                                        ]
-                                                                    },
-                                                                    "1:1": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                            "70": {
-                                                                                "title": "1:1 crop at 70px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            },
-                                                                            "140": {
-                                                                                "title": "1:1 crop at 140px width",
-                                                                                "type": "string",
-                                                                                "format": "uri",
-                                                                                "pattern": "^https://"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "70",
-                                                                            "140"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "2:1",
-                                                                    "16:9",
-                                                                    "1:1"
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "paragraph"
                                                                 ]
+                                                            },
+                                                            "text": {
+                                                                "title": "Text",
+                                                                "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "alt",
-                                                            "sizes"
+                                                            "type",
+                                                            "text"
                                                         ]
-                                                    }
+                                                    },
+                                                    "minItems": 1
                                                 }
-                                            }
-                                        ]
+                                            },
+                                            "required": [
+                                                "doi",
+                                                "content"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "id",
+                                        "version",
+                                        "type",
+                                        "doi",
+                                        "title",
+                                        "published",
+                                        "volume",
+                                        "elocationId"
+                                    ]
+                                },
+                                {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "poa"
+                                            ]
+                                        }
                                     }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            },
+                                }
+                            ]
+                        },
+                        {
+                            "$schema": "http://json-schema.org/draft-04/schema#",
+                            "title": "Article VoR snippet",
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/properties/items/items/0/oneOf/0/allOf/0"
+                                },
+                                {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "vor"
+                                            ]
+                                        },
+                                        "impactStatement": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "image": {
+                                            "$schema": "http://json-schema.org/draft-04/schema#",
+                                            "title": "Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "alt": {
+                                                    "title": "Alternative text",
+                                                    "type": "string"
+                                                },
+                                                "sizes": {
+                                                    "title": "Sizes",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "2:1": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "900": {
+                                                                    "title": "2:1 crop at 900px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                },
+                                                                "1800": {
+                                                                    "title": "2:1 crop at 1800px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "900",
+                                                                "1800"
+                                                            ]
+                                                        },
+                                                        "16:9": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "250": {
+                                                                    "title": "16:9 crop at 250px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                },
+                                                                "500": {
+                                                                    "title": "16:9 crop at 500px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "250",
+                                                                "500"
+                                                            ]
+                                                        },
+                                                        "1:1": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "70": {
+                                                                    "title": "1:1 crop at 70px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                },
+                                                                "140": {
+                                                                    "title": "1:1 crop at 140px width",
+                                                                    "type": "string",
+                                                                    "format": "uri",
+                                                                    "pattern": "^https://"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "70",
+                                                                "140"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "2:1",
+                                                        "16:9",
+                                                        "1:1"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "alt",
+                                                "sizes"
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "uniqueItems": true
         }
     },

--- a/dist/model/article-poa.v1.json
+++ b/dist/model/article-poa.v1.json
@@ -5,171 +5,199 @@
     "allOf": [
         {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "title": "Article PoA snippet",
+            "title": "Article",
             "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "version": {
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "correction",
-                        "editorial",
-                        "feature",
-                        "insight",
-                        "research-advance",
-                        "research-article",
-                        "research-exchange",
-                        "retraction",
-                        "registered-report",
-                        "replication-study",
-                        "short-report",
-                        "tools-resources"
-                    ]
-                },
-                "doi": {
+            "allOf": [
+                {
                     "$schema": "http://json-schema.org/draft-04/schema#",
-                    "title": "DOI",
-                    "type": "string",
-                    "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
-                },
-                "title": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "published": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "volume": {
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "elocationId": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "pdf": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "subjects": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    "uniqueItems": true
-                },
-                "researchOrganisms": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    "uniqueItems": true
-                },
-                "relatedArticles": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    "uniqueItems": true
-                },
-                "abstract": {
+                    "title": "Article snippet",
                     "type": "object",
                     "properties": {
-                        "doi": {
-                            "$ref": "#/allOf/0/properties/doi"
+                        "id": {
+                            "type": "string",
+                            "minLength": 1
                         },
-                        "content": {
+                        "version": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "correction",
+                                "editorial",
+                                "feature",
+                                "insight",
+                                "research-advance",
+                                "research-article",
+                                "research-exchange",
+                                "retraction",
+                                "registered-report",
+                                "replication-study",
+                                "short-report",
+                                "tools-resources"
+                            ]
+                        },
+                        "doi": {
+                            "$schema": "http://json-schema.org/draft-04/schema#",
+                            "title": "DOI",
+                            "type": "string",
+                            "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
+                        },
+                        "title": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "published": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "volume": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "elocationId": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "pdf": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "subjects": {
                             "type": "array",
                             "items": {
-                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                "title": "Paragraph",
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": [
-                                            "paragraph"
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "uniqueItems": true
+                        },
+                        "researchOrganisms": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "uniqueItems": true
+                        },
+                        "relatedArticles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "uniqueItems": true
+                        },
+                        "abstract": {
+                            "type": "object",
+                            "properties": {
+                                "doi": {
+                                    "$ref": "#/allOf/0/allOf/0/properties/doi"
+                                },
+                                "content": {
+                                    "type": "array",
+                                    "items": {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "title": "Paragraph",
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "paragraph"
+                                                ]
+                                            },
+                                            "text": {
+                                                "title": "Text",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "text"
                                         ]
                                     },
-                                    "text": {
-                                        "title": "Text",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "type",
-                                    "text"
-                                ]
+                                    "minItems": 1
+                                }
                             },
-                            "minItems": 1
+                            "required": [
+                                "doi",
+                                "content"
+                            ]
                         }
                     },
                     "required": [
+                        "status",
+                        "id",
+                        "version",
+                        "type",
                         "doi",
-                        "content"
+                        "title",
+                        "published",
+                        "volume",
+                        "elocationId"
+                    ]
+                },
+                {
+                    "properties": {
+                        "issue": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "copyright": {
+                            "type": "object",
+                            "properties": {
+                                "license": {
+                                    "type": "string",
+                                    "enum": [
+                                        "CC-BY-1.0",
+                                        "CC-BY-2.0",
+                                        "CC-BY-2.5",
+                                        "CC-BY-3.0",
+                                        "CC-BY-4.0",
+                                        "CC0-1.0"
+                                    ]
+                                },
+                                "holder": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "statement": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "license",
+                                "holder",
+                                "statement"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "copyright"
                     ]
                 }
-            },
-            "required": [
-                "id",
-                "version",
-                "type",
-                "doi",
-                "title",
-                "published",
-                "volume",
-                "elocationId"
             ]
         },
         {
-            "properties": {
-                "issue": {
-                    "type": "integer",
-                    "minimum": 1
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "title": "Article PoA snippet",
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/allOf/0/allOf/0"
                 },
-                "copyright": {
-                    "type": "object",
+                {
                     "properties": {
-                        "license": {
+                        "status": {
                             "type": "string",
                             "enum": [
-                                "CC-BY-1.0",
-                                "CC-BY-2.0",
-                                "CC-BY-2.5",
-                                "CC-BY-3.0",
-                                "CC-BY-4.0",
-                                "CC0-1.0"
+                                "poa"
                             ]
-                        },
-                        "holder": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "statement": {
-                            "type": "string",
-                            "minLength": 1
                         }
-                    },
-                    "required": [
-                        "license",
-                        "holder",
-                        "statement"
-                    ]
+                    }
                 }
-            },
-            "required": [
-                "copyright"
             ]
         }
     ]

--- a/dist/model/article-vor.v1.json
+++ b/dist/model/article-vor.v1.json
@@ -5,12 +5,12 @@
     "allOf": [
         {
             "$schema": "http://json-schema.org/draft-04/schema#",
-            "title": "Article PoA",
+            "title": "Article",
             "type": "object",
             "allOf": [
                 {
                     "$schema": "http://json-schema.org/draft-04/schema#",
-                    "title": "Article PoA snippet",
+                    "title": "Article snippet",
                     "type": "object",
                     "properties": {
                         "id": {
@@ -106,6 +106,7 @@
                         }
                     },
                     "required": [
+                        "status",
                         "id",
                         "version",
                         "type",
@@ -168,6 +169,12 @@
                 },
                 {
                     "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": [
+                                "vor"
+                            ]
+                        },
                         "impactStatement": {
                             "type": "string",
                             "minLength": 1

--- a/dist/model/search.v1.json
+++ b/dist/model/search.v1.json
@@ -12,534 +12,494 @@
             "title": "Search results",
             "type": "array",
             "items": {
-                "allOf": [
+                "oneOf": [
                     {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "title": "Article VoR snippet",
                         "type": "object",
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    {
-                        "oneOf": [
+                        "allOf": [
                             {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "correction",
-                                                    "editorial",
-                                                    "feature",
-                                                    "insight",
-                                                    "research-advance",
-                                                    "research-article",
-                                                    "research-exchange",
-                                                    "retraction",
-                                                    "registered-report",
-                                                    "replication-study",
-                                                    "short-report",
-                                                    "tools-resources"
-                                                ]
-                                            },
-                                            "status": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "poa"
-                                                ]
-                                            }
-                                        },
-                                        "required": [
-                                            "status"
+                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                "title": "Article snippet",
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "version": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "correction",
+                                            "editorial",
+                                            "feature",
+                                            "insight",
+                                            "research-advance",
+                                            "research-article",
+                                            "research-exchange",
+                                            "retraction",
+                                            "registered-report",
+                                            "replication-study",
+                                            "short-report",
+                                            "tools-resources"
                                         ]
                                     },
-                                    {
+                                    "doi": {
                                         "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Article PoA snippet",
+                                        "title": "DOI",
+                                        "type": "string",
+                                        "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
+                                    },
+                                    "title": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "published": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "volume": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "elocationId": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "pdf": {
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "subjects": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "uniqueItems": true
+                                    },
+                                    "researchOrganisms": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "uniqueItems": true
+                                    },
+                                    "relatedArticles": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "uniqueItems": true
+                                    },
+                                    "abstract": {
                                         "type": "object",
                                         "properties": {
-                                            "id": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "version": {
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "correction",
-                                                    "editorial",
-                                                    "feature",
-                                                    "insight",
-                                                    "research-advance",
-                                                    "research-article",
-                                                    "research-exchange",
-                                                    "retraction",
-                                                    "registered-report",
-                                                    "replication-study",
-                                                    "short-report",
-                                                    "tools-resources"
-                                                ]
-                                            },
                                             "doi": {
-                                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                                "title": "DOI",
-                                                "type": "string",
-                                                "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
+                                                "$ref": "#/properties/items/items/oneOf/0/allOf/0/properties/doi"
                                             },
-                                            "title": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "published": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "volume": {
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "elocationId": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "pdf": {
-                                                "type": "string",
-                                                "format": "uri"
-                                            },
-                                            "subjects": {
+                                            "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "researchOrganisms": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "relatedArticles": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true
-                                            },
-                                            "abstract": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "doi": {
-                                                        "$ref": "#/properties/items/items/allOf/1/oneOf/0/allOf/1/properties/doi"
-                                                    },
-                                                    "content": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "$schema": "http://json-schema.org/draft-04/schema#",
-                                                            "title": "Paragraph",
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "type": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "paragraph"
-                                                                    ]
-                                                                },
-                                                                "text": {
-                                                                    "title": "Text",
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type",
-                                                                "text"
+                                                    "$schema": "http://json-schema.org/draft-04/schema#",
+                                                    "title": "Paragraph",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "paragraph"
                                                             ]
                                                         },
-                                                        "minItems": 1
-                                                    }
-                                                },
-                                                "required": [
-                                                    "doi",
-                                                    "content"
-                                                ]
-                                            }
-                                        },
-                                        "required": [
-                                            "id",
-                                            "version",
-                                            "type",
-                                            "doi",
-                                            "title",
-                                            "published",
-                                            "volume",
-                                            "elocationId"
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "correction",
-                                                    "editorial",
-                                                    "feature",
-                                                    "insight",
-                                                    "research-advance",
-                                                    "research-article",
-                                                    "research-exchange",
-                                                    "retraction",
-                                                    "registered-report",
-                                                    "replication-study",
-                                                    "short-report",
-                                                    "tools-resources"
-                                                ]
-                                            },
-                                            "status": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "vor"
-                                                ]
-                                            }
-                                        },
-                                        "required": [
-                                            "status"
-                                        ]
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Article VoR snippet",
-                                        "type": "object",
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/properties/items/items/allOf/1/oneOf/0/allOf/1"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "impactStatement": {
-                                                        "type": "string",
-                                                        "minLength": 1
+                                                        "text": {
+                                                            "title": "Text",
+                                                            "type": "string"
+                                                        }
                                                     },
-                                                    "image": {
-                                                        "$ref": "#/properties/items/items/allOf/1/oneOf/5/allOf/1/properties/image"
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "blog-article"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Blog article snippet",
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "description": "ID",
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "title": {
-                                                "description": "Title",
-                                                "type": "string"
-                                            },
-                                            "impactStatement": {
-                                                "description": "Description of the article",
-                                                "type": "string"
-                                            },
-                                            "published": {
-                                                "description": "Publication date (UTC)",
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "subjects": {
-                                                "description": "Article subject IDs",
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
+                                                    "required": [
+                                                        "type",
+                                                        "text"
+                                                    ]
                                                 },
-                                                "uniqueItems": true
+                                                "minItems": 1
                                             }
                                         },
                                         "required": [
-                                            "id",
-                                            "title",
-                                            "published"
+                                            "doi",
+                                            "content"
                                         ]
                                     }
+                                },
+                                "required": [
+                                    "status",
+                                    "id",
+                                    "version",
+                                    "type",
+                                    "doi",
+                                    "title",
+                                    "published",
+                                    "volume",
+                                    "elocationId"
                                 ]
                             },
                             {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "event"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Event snippet",
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "description": "ID",
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "title": {
-                                                "description": "Title",
-                                                "type": "string"
-                                            },
-                                            "impactStatement": {
-                                                "description": "Description of the article",
-                                                "type": "string"
-                                            },
-                                            "starts": {
-                                                "description": "Start date/time (UTC)",
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "ends": {
-                                                "description": "Ends date/time (UTC)",
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "timezone": {
-                                                "description": "Timezone (from the IANA time zone database) for non-online events",
-                                                "type": "string",
-                                                "pattern": "^[A-Za-z]+(/[A-Za-z_-]+)+$"
-                                            }
-                                        },
-                                        "required": [
-                                            "id",
-                                            "title",
-                                            "starts",
-                                            "ends"
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "vor"
                                         ]
-                                    }
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "labs-experiment"
-                                                ]
-                                            }
-                                        }
                                     },
-                                    {
+                                    "impactStatement": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "image": {
                                         "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Labs experiment snippet",
+                                        "title": "Image",
                                         "type": "object",
                                         "properties": {
-                                            "number": {
-                                                "description": "Number",
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "title": {
-                                                "description": "Title",
+                                            "alt": {
+                                                "title": "Alternative text",
                                                 "type": "string"
                                             },
-                                            "impactStatement": {
-                                                "description": "Description of the experiment",
-                                                "type": "string"
-                                            },
-                                            "published": {
-                                                "description": "Publication date (UTC)",
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "image": {
-                                                "$ref": "#/properties/items/items/allOf/1/oneOf/5/allOf/1/properties/image"
-                                            }
-                                        },
-                                        "required": [
-                                            "number",
-                                            "title",
-                                            "published",
-                                            "image"
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "podcast-episode"
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$schema": "http://json-schema.org/draft-04/schema#",
-                                        "title": "Podcast episode snippet",
-                                        "type": "object",
-                                        "properties": {
-                                            "number": {
-                                                "description": "Number",
-                                                "type": "integer",
-                                                "minimum": 1
-                                            },
-                                            "title": {
-                                                "description": "Title",
-                                                "type": "string"
-                                            },
-                                            "impactStatement": {
-                                                "description": "Description of the episode",
-                                                "type": "string"
-                                            },
-                                            "published": {
-                                                "description": "Publication date (UTC)",
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "image": {
-                                                "$schema": "http://json-schema.org/draft-04/schema#",
-                                                "title": "Image",
+                                            "sizes": {
+                                                "title": "Sizes",
                                                 "type": "object",
                                                 "properties": {
-                                                    "alt": {
-                                                        "title": "Alternative text",
-                                                        "type": "string"
-                                                    },
-                                                    "sizes": {
-                                                        "title": "Sizes",
+                                                    "2:1": {
                                                         "type": "object",
                                                         "properties": {
-                                                            "2:1": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "900": {
-                                                                        "title": "2:1 crop at 900px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    },
-                                                                    "1800": {
-                                                                        "title": "2:1 crop at 1800px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "900",
-                                                                    "1800"
-                                                                ]
+                                                            "900": {
+                                                                "title": "2:1 crop at 900px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
                                                             },
-                                                            "16:9": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "250": {
-                                                                        "title": "16:9 crop at 250px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    },
-                                                                    "500": {
-                                                                        "title": "16:9 crop at 500px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "250",
-                                                                    "500"
-                                                                ]
-                                                            },
-                                                            "1:1": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "70": {
-                                                                        "title": "1:1 crop at 70px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    },
-                                                                    "140": {
-                                                                        "title": "1:1 crop at 140px width",
-                                                                        "type": "string",
-                                                                        "format": "uri",
-                                                                        "pattern": "^https://"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "70",
-                                                                    "140"
-                                                                ]
+                                                            "1800": {
+                                                                "title": "2:1 crop at 1800px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
                                                             }
                                                         },
                                                         "required": [
-                                                            "2:1",
-                                                            "16:9",
-                                                            "1:1"
+                                                            "900",
+                                                            "1800"
+                                                        ]
+                                                    },
+                                                    "16:9": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "250": {
+                                                                "title": "16:9 crop at 250px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
+                                                            },
+                                                            "500": {
+                                                                "title": "16:9 crop at 500px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "250",
+                                                            "500"
+                                                        ]
+                                                    },
+                                                    "1:1": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "70": {
+                                                                "title": "1:1 crop at 70px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
+                                                            },
+                                                            "140": {
+                                                                "title": "1:1 crop at 140px width",
+                                                                "type": "string",
+                                                                "format": "uri",
+                                                                "pattern": "^https://"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "70",
+                                                            "140"
                                                         ]
                                                     }
                                                 },
                                                 "required": [
-                                                    "alt",
-                                                    "sizes"
+                                                    "2:1",
+                                                    "16:9",
+                                                    "1:1"
                                                 ]
-                                            },
-                                            "mp3": {
-                                                "description": "URI of the MP3",
-                                                "type": "string",
-                                                "format": "uri",
-                                                "pattern": "^https://"
-                                            },
-                                            "subjects": {
-                                                "description": "Episode subject IDs",
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                }
                                             }
                                         },
                                         "required": [
-                                            "number",
-                                            "title",
-                                            "published",
-                                            "image",
-                                            "mp3"
+                                            "alt",
+                                            "sizes"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "title": "Article PoA snippet",
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "$ref": "#/properties/items/items/oneOf/0/allOf/0"
+                            },
+                            {
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "poa"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "type": "object",
+                                "required": [
+                                    "type"
+                                ]
+                            },
+                            {
+                                "oneOf": [
+                                    {
+                                        "allOf": [
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "blog-article"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                                "title": "Blog article snippet",
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "description": "ID",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                    },
+                                                    "title": {
+                                                        "description": "Title",
+                                                        "type": "string"
+                                                    },
+                                                    "impactStatement": {
+                                                        "description": "Description of the article",
+                                                        "type": "string"
+                                                    },
+                                                    "published": {
+                                                        "description": "Publication date (UTC)",
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "subjects": {
+                                                        "description": "Article subject IDs",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                        },
+                                                        "uniqueItems": true
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "title",
+                                                    "published"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "event"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                                "title": "Event snippet",
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "description": "ID",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                    },
+                                                    "title": {
+                                                        "description": "Title",
+                                                        "type": "string"
+                                                    },
+                                                    "impactStatement": {
+                                                        "description": "Description of the article",
+                                                        "type": "string"
+                                                    },
+                                                    "starts": {
+                                                        "description": "Start date/time (UTC)",
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "ends": {
+                                                        "description": "Ends date/time (UTC)",
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "timezone": {
+                                                        "description": "Timezone (from the IANA time zone database) for non-online events",
+                                                        "type": "string",
+                                                        "pattern": "^[A-Za-z]+(/[A-Za-z_-]+)+$"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "title",
+                                                    "starts",
+                                                    "ends"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "labs-experiment"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                                "title": "Labs experiment snippet",
+                                                "type": "object",
+                                                "properties": {
+                                                    "number": {
+                                                        "description": "Number",
+                                                        "type": "integer",
+                                                        "minimum": 1
+                                                    },
+                                                    "title": {
+                                                        "description": "Title",
+                                                        "type": "string"
+                                                    },
+                                                    "impactStatement": {
+                                                        "description": "Description of the experiment",
+                                                        "type": "string"
+                                                    },
+                                                    "published": {
+                                                        "description": "Publication date (UTC)",
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "image": {
+                                                        "$ref": "#/properties/items/items/oneOf/0/allOf/1/properties/image"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "number",
+                                                    "title",
+                                                    "published",
+                                                    "image"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "podcast-episode"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                                "title": "Podcast episode snippet",
+                                                "type": "object",
+                                                "properties": {
+                                                    "number": {
+                                                        "description": "Number",
+                                                        "type": "integer",
+                                                        "minimum": 1
+                                                    },
+                                                    "title": {
+                                                        "description": "Title",
+                                                        "type": "string"
+                                                    },
+                                                    "impactStatement": {
+                                                        "description": "Description of the episode",
+                                                        "type": "string"
+                                                    },
+                                                    "published": {
+                                                        "description": "Publication date (UTC)",
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "image": {
+                                                        "$ref": "#/properties/items/items/oneOf/0/allOf/1/properties/image"
+                                                    },
+                                                    "mp3": {
+                                                        "description": "URI of the MP3",
+                                                        "type": "string",
+                                                        "format": "uri",
+                                                        "pattern": "^https://"
+                                                    },
+                                                    "subjects": {
+                                                        "description": "Episode subject IDs",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "number",
+                                                    "title",
+                                                    "published",
+                                                    "image",
+                                                    "mp3"
+                                                ]
+                                            }
                                         ]
                                     }
                                 ]

--- a/dist/samples/article-poa/v1/complete.json
+++ b/dist/samples/article-poa/v1/complete.json
@@ -1,4 +1,5 @@
 {
+    "status": "poa",
     "id": "14107",
     "version": 1,
     "type": "research-article",

--- a/dist/samples/article-poa/v1/minimum.json
+++ b/dist/samples/article-poa/v1/minimum.json
@@ -1,4 +1,5 @@
 {
+    "status": "poa",
     "id": "14107",
     "version": 1,
     "type": "research-article",

--- a/dist/samples/article-vor/v1/complete.json
+++ b/dist/samples/article-vor/v1/complete.json
@@ -1,4 +1,5 @@
 {
+    "status": "vor",
     "id": "09560",
     "version": 1,
     "type": "research-article",

--- a/dist/samples/article-vor/v1/minimum.json
+++ b/dist/samples/article-vor/v1/minimum.json
@@ -1,4 +1,5 @@
 {
+    "status": "vor",
     "id": "09560",
     "version": 1,
     "type": "research-article",

--- a/src/api.raml
+++ b/src/api.raml
@@ -301,7 +301,7 @@ traits:
                                             value: !include samples/article-poa/v1/minimum.json
                                         complete:
                                             displayName: Complete
-                                            value: !include samples/article-vor/v1/complete.json
+                                            value: !include samples/article-poa/v1/complete.json
                                 application/vnd.elife.article-vor+json;version=1:
                                     schema: !include ../dist/model/article-vor.v1.json
                                     examples:

--- a/src/misc/article.v1.yaml
+++ b/src/misc/article.v1.yaml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Article
+type: object
+allOf:
+  - $ref: ../snippets/article.v1.yaml
+  - properties:
+        issue:
+            type: integer
+            minimum: 1
+        copyright:
+            type: object
+            properties:
+                license:
+                    type: string
+                    enum:
+                      - CC-BY-1.0
+                      - CC-BY-2.0
+                      - CC-BY-2.5
+                      - CC-BY-3.0
+                      - CC-BY-4.0
+                      - CC0-1.0
+                holder:
+                    type: string
+                    minLength: 1
+                statement:
+                    type: string
+                    minLength: 1
+            required:
+              - license
+              - holder
+              - statement
+    required:
+      - copyright

--- a/src/model/article-list.v1.yaml
+++ b/src/model/article-list.v1.yaml
@@ -10,25 +10,9 @@ properties:
         title: Articles
         type: array
         items:
-            allOf:
-              - type: object
-                required:
-                  - status
-              - oneOf:
-                  - allOf:
-                      - properties:
-                            status:
-                                type: string
-                                enum:
-                                  - poa
-                      - $ref: ../snippets/article-poa.v1.yaml
-                  - allOf:
-                      - properties:
-                            status:
-                                type: string
-                                enum:
-                                  - vor
-                      - $ref: ../snippets/article-vor.v1.yaml
+          - oneOf:
+              - $ref: ../snippets/article-poa.v1.yaml
+              - $ref: ../snippets/article-vor.v1.yaml
         uniqueItems: true
 required:
   - total

--- a/src/model/article-poa.v1.yaml
+++ b/src/model/article-poa.v1.yaml
@@ -2,32 +2,5 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article PoA
 type: object
 allOf:
+  - $ref: ../misc/article.v1.yaml
   - $ref: ../snippets/article-poa.v1.yaml
-  - properties:
-        issue:
-            type: integer
-            minimum: 1
-        copyright:
-            type: object
-            properties:
-                license:
-                    type: string
-                    enum:
-                      - CC-BY-1.0
-                      - CC-BY-2.0
-                      - CC-BY-2.5
-                      - CC-BY-3.0
-                      - CC-BY-4.0
-                      - CC0-1.0
-                holder:
-                    type: string
-                    minLength: 1
-                statement:
-                    type: string
-                    minLength: 1
-            required:
-              - license
-              - holder
-              - statement
-    required:
-      - copyright

--- a/src/model/article-vor.v1.yaml
+++ b/src/model/article-vor.v1.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR
 type: object
 allOf:
-  - $ref: article-poa.v1.yaml
+  - $ref: ../misc/article.v1.yaml
   - $ref: ../snippets/article-vor.v1.yaml
   - properties:
         keywords:

--- a/src/model/search.v1.yaml
+++ b/src/model/search.v1.yaml
@@ -10,87 +10,42 @@ properties:
         title: Search results
         type: array
         items:
-            allOf:
-              - type: object
-                required:
-                  - type
-              - oneOf:
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - correction
-                                  - editorial
-                                  - feature
-                                  - insight
-                                  - research-advance
-                                  - research-article
-                                  - research-exchange
-                                  - retraction
-                                  - registered-report
-                                  - replication-study
-                                  - short-report
-                                  - tools-resources
-                            status:
-                                type: string
-                                enum:
-                                  - poa
-                        required:
-                          - status
-                      - $ref: ../snippets/article-poa.v1.yaml
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - correction
-                                  - editorial
-                                  - feature
-                                  - insight
-                                  - research-advance
-                                  - research-article
-                                  - research-exchange
-                                  - retraction
-                                  - registered-report
-                                  - replication-study
-                                  - short-report
-                                  - tools-resources
-                            status:
-                                type: string
-                                enum:
-                                  - vor
-                        required:
-                          - status
-                      - $ref: ../snippets/article-vor.v1.yaml
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - blog-article
-                      - $ref: ../snippets/blog-article.v1.yaml
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - event
-                      - $ref: ../snippets/event.v1.yaml
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - labs-experiment
-                      - $ref: ../snippets/labs-experiment.v1.yaml
-                  - allOf:
-                      - properties:
-                            type:
-                                type: string
-                                enum:
-                                  - podcast-episode
-                      - $ref: ../snippets/podcast-episode.v1.yaml
+            oneOf:
+              - $ref: ../snippets/article-vor.v1.yaml
+              - $ref: ../snippets/article-poa.v1.yaml
+              - allOf:
+                  - type: object
+                    required:
+                      - type
+                  - oneOf:
+                      - allOf:
+                          - properties:
+                                type:
+                                    type: string
+                                    enum:
+                                      - blog-article
+                          - $ref: ../snippets/blog-article.v1.yaml
+                      - allOf:
+                          - properties:
+                                type:
+                                    type: string
+                                    enum:
+                                      - event
+                          - $ref: ../snippets/event.v1.yaml
+                      - allOf:
+                          - properties:
+                                type:
+                                    type: string
+                                    enum:
+                                      - labs-experiment
+                          - $ref: ../snippets/labs-experiment.v1.yaml
+                      - allOf:
+                          - properties:
+                                type:
+                                    type: string
+                                    enum:
+                                      - podcast-episode
+                          - $ref: ../snippets/podcast-episode.v1.yaml
         uniqueItems: true
     subjects:
         title: Subjects

--- a/src/samples/article-poa/v1/complete.json
+++ b/src/samples/article-poa/v1/complete.json
@@ -1,4 +1,5 @@
 {
+    "status": "poa",
     "id": "14107",
     "version": 1,
     "type": "research-article",

--- a/src/samples/article-poa/v1/minimum.json
+++ b/src/samples/article-poa/v1/minimum.json
@@ -1,4 +1,5 @@
 {
+    "status": "poa",
     "id": "14107",
     "version": 1,
     "type": "research-article",

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -1,4 +1,5 @@
 {
+    "status": "vor",
     "id": "09560",
     "version": 1,
     "type": "research-article",

--- a/src/samples/article-vor/v1/minimum.json
+++ b/src/samples/article-vor/v1/minimum.json
@@ -1,4 +1,5 @@
 {
+    "status": "vor",
     "id": "09560",
     "version": 1,
     "type": "research-article",

--- a/src/snippets/article-poa.v1.yaml
+++ b/src/snippets/article-poa.v1.yaml
@@ -1,82 +1,10 @@
 $schema: http://json-schema.org/draft-04/schema#
 title: Article PoA snippet
 type: object
-properties:
-    id:
-        type: string
-        minLength: 1
-    version:
-        type: integer
-        minimum: 1
-    type:
-        type: string
-        enum:
-          - correction
-          - editorial
-          - feature
-          - insight
-          - research-advance
-          - research-article
-          - research-exchange
-          - retraction
-          - registered-report
-          - replication-study
-          - short-report
-          - tools-resources
-    doi:
-        $ref: ../misc/doi.yaml
-    title:
-        type: string
-        minLength: 1
-    published:
-        type: string
-        format: date-time
-    volume:
-        type: integer
-        minimum: 1
-    elocationId:
-        type: string
-        minLength: 1
-    pdf:
-        type: string
-        format: uri
-    subjects:
-        type: array
-        items:
+allOf:
+  - $ref: article.v1.yaml
+  - properties:
+        status:
             type: string
-            minLength: 1
-        uniqueItems: true
-    researchOrganisms:
-        type: array
-        items:
-            type: string
-            minLength: 1
-        uniqueItems: true
-    relatedArticles:
-        type: array
-        items:
-            type: string
-            minLength: 1
-        uniqueItems: true
-    abstract:
-        type: object
-        properties:
-            doi:
-                $ref: ../misc/doi.yaml
-            content:
-                type: array
-                items:
-                    $ref: ../blocks/paragraph.v1.yaml
-                minItems: 1
-        required:
-          - doi
-          - content
-required:
-  - id
-  - version
-  - type
-  - doi
-  - title
-  - published
-  - volume
-  - elocationId
+            enum:
+              - poa

--- a/src/snippets/article-vor.v1.yaml
+++ b/src/snippets/article-vor.v1.yaml
@@ -2,8 +2,12 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR snippet
 type: object
 allOf:
-  - $ref: article-poa.v1.yaml
+  - $ref: article.v1.yaml
   - properties:
+        status:
+            type: string
+            enum:
+              - vor
         impactStatement:
             type: string
             minLength: 1

--- a/src/snippets/article.v1.yaml
+++ b/src/snippets/article.v1.yaml
@@ -1,0 +1,83 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Article snippet
+type: object
+properties:
+    id:
+        type: string
+        minLength: 1
+    version:
+        type: integer
+        minimum: 1
+    type:
+        type: string
+        enum:
+          - correction
+          - editorial
+          - feature
+          - insight
+          - research-advance
+          - research-article
+          - research-exchange
+          - retraction
+          - registered-report
+          - replication-study
+          - short-report
+          - tools-resources
+    doi:
+        $ref: ../misc/doi.yaml
+    title:
+        type: string
+        minLength: 1
+    published:
+        type: string
+        format: date-time
+    volume:
+        type: integer
+        minimum: 1
+    elocationId:
+        type: string
+        minLength: 1
+    pdf:
+        type: string
+        format: uri
+    subjects:
+        type: array
+        items:
+            type: string
+            minLength: 1
+        uniqueItems: true
+    researchOrganisms:
+        type: array
+        items:
+            type: string
+            minLength: 1
+        uniqueItems: true
+    relatedArticles:
+        type: array
+        items:
+            type: string
+            minLength: 1
+        uniqueItems: true
+    abstract:
+        type: object
+        properties:
+            doi:
+                $ref: ../misc/doi.yaml
+            content:
+                type: array
+                items:
+                    $ref: ../blocks/paragraph.v1.yaml
+                minItems: 1
+        required:
+          - doi
+          - content
+required:
+  - status
+  - id
+  - version
+  - type
+  - doi
+  - title
+  - published
+  - volume
+  - elocationId


### PR DESCRIPTION
@lsh-0 has requested having the article `status` property included in the full article version.

We had to include this in listings to distinguish between PoA and VoR already, but individually the content type would have had to be used.
