### PR TITLE
Bundle JSON references a second time

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -27,9 +27,16 @@ recursive('./src/model', function (err, files) {
                 var jsonFile = './dist/model/' + file.slice(10, (file.length - 4)) + 'json';
                 var json = JSON.stringify(schema, null, 4) + '\n';
                 fs.writeFileSync(jsonFile, json);
+                return jsonFile;
             }).catch(function (error) {
                 console.error(error);
                 process.exit(1);
+            }).then(function (jsonFile) {
+                var parser = new refParser();
+                return parser.bundle(jsonFile).then(function (schema) {
+                    var json = JSON.stringify(schema, null, 4) + '\n';
+                    fs.writeFileSync(jsonFile, json);
+                })
             }));
         }(file))
     }

--- a/compile.js
+++ b/compile.js
@@ -32,6 +32,7 @@ recursive('./src/model', function (err, files) {
                 console.error(error);
                 process.exit(1);
             }).then(function (jsonFile) {
+                // Bundle again due to https://github.com/BigstickCarpet/json-schema-ref-parser/issues/24
                 var parser = new refParser();
                 return parser.bundle(jsonFile).then(function (schema) {
                     var json = JSON.stringify(schema, null, 4) + '\n';

--- a/dist/model/article-vor.v1.json
+++ b/dist/model/article-vor.v1.json
@@ -152,7 +152,7 @@
                             ]
                         },
                         "doi": {
-                            "$ref": "#/allOf/2/properties/decisionLetter/properties/doi"
+                            "$ref": "#/allOf/2/properties/digest/properties/doi"
                         },
                         "title": {
                             "type": "string",
@@ -202,12 +202,12 @@
                             "type": "object",
                             "properties": {
                                 "doi": {
-                                    "$ref": "#/allOf/2/properties/decisionLetter/properties/doi"
+                                    "$ref": "#/allOf/2/properties/digest/properties/doi"
                                 },
                                 "content": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/allOf/2/properties/decisionLetter/properties/description/items"
+                                        "$ref": "#/allOf/2/properties/digest/properties/content/items"
                                     },
                                     "minItems": 1
                                 }
@@ -285,31 +285,12 @@
                     "type": "object",
                     "properties": {
                         "doi": {
-                            "$ref": "#/allOf/2/properties/decisionLetter/properties/doi"
-                        },
-                        "content": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/allOf/2/properties/decisionLetter/properties/description/items"
-                            },
-                            "minItems": 1
-                        }
-                    },
-                    "required": [
-                        "doi",
-                        "content"
-                    ]
-                },
-                "decisionLetter": {
-                    "type": "object",
-                    "properties": {
-                        "doi": {
                             "$schema": "http://json-schema.org/draft-04/schema#",
                             "title": "DOI",
                             "type": "string",
                             "pattern": "^10[.][0-9]{4,}[^\\s\"/<>]*/[^\\s\"]+$"
                         },
-                        "description": {
+                        "content": {
                             "type": "array",
                             "items": {
                                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -331,6 +312,59 @@
                                     "type",
                                     "text"
                                 ]
+                            },
+                            "minItems": 1
+                        }
+                    },
+                    "required": [
+                        "doi",
+                        "content"
+                    ]
+                },
+                "body": {
+                    "type": "array",
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "title": "Section",
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "section"
+                                ]
+                            },
+                            "title": {
+                                "title": "Text",
+                                "type": "string"
+                            },
+                            "content": {
+                                "description": "Content",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/allOf/2/properties/decisionLetter/properties/content/items"
+                                },
+                                "minItems": 1
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "title",
+                            "content"
+                        ]
+                    },
+                    "minItems": 1
+                },
+                "decisionLetter": {
+                    "type": "object",
+                    "properties": {
+                        "doi": {
+                            "$ref": "#/allOf/2/properties/digest/properties/doi"
+                        },
+                        "description": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/allOf/2/properties/digest/properties/content/items"
                             },
                             "minItems": 1
                         },
@@ -428,7 +462,7 @@
                                                                             "$ref": "#/allOf/2/properties/decisionLetter/properties/content/items/oneOf/0/oneOf/0/oneOf/2"
                                                                         },
                                                                         {
-                                                                            "$ref": "#/allOf/2/properties/decisionLetter/properties/description/items"
+                                                                            "$ref": "#/allOf/2/properties/digest/properties/content/items"
                                                                         }
                                                                     ]
                                                                 },
@@ -441,7 +475,7 @@
                                                         ]
                                                     },
                                                     {
-                                                        "$ref": "#/allOf/2/properties/decisionLetter/properties/description/items"
+                                                        "$ref": "#/allOf/2/properties/digest/properties/content/items"
                                                     },
                                                     {
                                                         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -552,45 +586,11 @@
                         "content"
                     ]
                 },
-                "body": {
-                    "type": "array",
-                    "items": {
-                        "$schema": "http://json-schema.org/draft-04/schema#",
-                        "title": "Section",
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "section"
-                                ]
-                            },
-                            "title": {
-                                "title": "Text",
-                                "type": "string"
-                            },
-                            "content": {
-                                "description": "Content",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/allOf/2/properties/decisionLetter/properties/content/items"
-                                },
-                                "minItems": 1
-                            }
-                        },
-                        "required": [
-                            "type",
-                            "title",
-                            "content"
-                        ]
-                    },
-                    "minItems": 1
-                },
                 "authorResponse": {
                     "type": "object",
                     "properties": {
                         "doi": {
-                            "$ref": "#/allOf/2/properties/decisionLetter/properties/doi"
+                            "$ref": "#/allOf/2/properties/digest/properties/doi"
                         },
                         "content": {
                             "type": "array",

--- a/dist/model/search.v1.json
+++ b/dist/model/search.v1.json
@@ -15,6 +15,26 @@
                 "oneOf": [
                     {
                         "$schema": "http://json-schema.org/draft-04/schema#",
+                        "title": "Article PoA snippet",
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "$ref": "#/properties/items/items/oneOf/1/allOf/0"
+                            },
+                            {
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "poa"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
                         "title": "Article VoR snippet",
                         "type": "object",
                         "allOf": [
@@ -102,7 +122,7 @@
                                         "type": "object",
                                         "properties": {
                                             "doi": {
-                                                "$ref": "#/properties/items/items/oneOf/0/allOf/0/properties/doi"
+                                                "$ref": "#/properties/items/items/oneOf/1/allOf/0/properties/doi"
                                             },
                                             "content": {
                                                 "type": "array",
@@ -247,26 +267,6 @@
                                         "required": [
                                             "alt",
                                             "sizes"
-                                        ]
-                                    }
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "$schema": "http://json-schema.org/draft-04/schema#",
-                        "title": "Article PoA snippet",
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "#/properties/items/items/oneOf/0/allOf/0"
-                            },
-                            {
-                                "properties": {
-                                    "status": {
-                                        "type": "string",
-                                        "enum": [
-                                            "poa"
                                         ]
                                     }
                                 }
@@ -427,7 +427,7 @@
                                                         "format": "date-time"
                                                     },
                                                     "image": {
-                                                        "$ref": "#/properties/items/items/oneOf/0/allOf/1/properties/image"
+                                                        "$ref": "#/properties/items/items/oneOf/1/allOf/1/properties/image"
                                                     }
                                                 },
                                                 "required": [
@@ -475,7 +475,7 @@
                                                         "format": "date-time"
                                                     },
                                                     "image": {
-                                                        "$ref": "#/properties/items/items/oneOf/0/allOf/1/properties/image"
+                                                        "$ref": "#/properties/items/items/oneOf/1/allOf/1/properties/image"
                                                     },
                                                     "mp3": {
                                                         "description": "URI of the MP3",

--- a/src/model/article-vor.v1.yaml
+++ b/src/model/article-vor.v1.yaml
@@ -23,6 +23,11 @@ allOf:
             required:
               - doi
               - content
+        body:
+            type: array
+            items:
+                $ref: ../blocks/section.v1.yaml
+            minItems: 1
         decisionLetter:
             type: object
             properties:
@@ -42,11 +47,6 @@ allOf:
               - doi
               - description
               - content
-        body:
-            type: array
-            items:
-                $ref: ../blocks/section.v1.yaml
-            minItems: 1
         authorResponse:
             type: object
             properties:

--- a/src/model/search.v1.yaml
+++ b/src/model/search.v1.yaml
@@ -11,8 +11,8 @@ properties:
         type: array
         items:
             oneOf:
-              - $ref: ../snippets/article-vor.v1.yaml
               - $ref: ../snippets/article-poa.v1.yaml
+              - $ref: ../snippets/article-vor.v1.yaml
               - allOf:
                   - type: object
                     required:


### PR DESCRIPTION
https://github.com/BigstickCarpet/json-schema-ref-parser/issues/24 can be worked around by having a second pass at the JSON references.

I've been able to reorder some existing properties to a sensible order as a result.
