### PR TITLE
Standardise eLife IDs

### DIFF
--- a/src/misc/id.v1.yaml
+++ b/src/misc/id.v1.yaml
@@ -1,0 +1,4 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: eLife ID
+type: string
+pattern: ^[a-z0-9-]+$

--- a/src/snippets/article.v1.yaml
+++ b/src/snippets/article.v1.yaml
@@ -3,8 +3,7 @@ title: Article snippet
 type: object
 properties:
     id:
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     version:
         type: integer
         minimum: 1

--- a/src/snippets/blog-article.v1.yaml
+++ b/src/snippets/blog-article.v1.yaml
@@ -3,9 +3,7 @@ title: Blog article snippet
 type: object
 properties:
     id:
-        description: ID
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     title:
         description: Title
         type: string

--- a/src/snippets/collection.v1.yaml
+++ b/src/snippets/collection.v1.yaml
@@ -3,9 +3,7 @@ title: Collection snippet
 type: object
 properties:
     id:
-        description: ID
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     title:
         description: Title
         type: string

--- a/src/snippets/event.v1.yaml
+++ b/src/snippets/event.v1.yaml
@@ -3,9 +3,7 @@ title: Event snippet
 type: object
 properties:
     id:
-        description: ID
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     title:
         description: Title
         type: string

--- a/src/snippets/interview.v1.yaml
+++ b/src/snippets/interview.v1.yaml
@@ -3,9 +3,7 @@ title: Interview snippet
 type: object
 properties:
     id:
-        description: ID
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     interviewee:
         $ref: ../misc/person.v1.yaml
     title:

--- a/src/snippets/person.v1.yaml
+++ b/src/snippets/person.v1.yaml
@@ -5,9 +5,7 @@ allOf:
   - $ref: ../misc/person.v1.yaml
   - properties:
         id:
-            title: ID
-            type: string
-            minLength: 1
+            $ref: ../misc/id.v1.yaml
         type:
             title: Type
             type: string

--- a/src/snippets/subject.v1.yaml
+++ b/src/snippets/subject.v1.yaml
@@ -3,9 +3,7 @@ title: Subject snippet
 type: object
 properties:
     id:
-        description: ID
-        type: string
-        minLength: 1
+        $ref: ../misc/id.v1.yaml
     name:
         description: Name
         type: string


### PR DESCRIPTION
Limits all content IDs (that aren't natural ones) to lowercase letters and numbers.
