### PR TITLE
Add IDs to articles sections

### DIFF
--- a/src/blocks/section.v1.yaml
+++ b/src/blocks/section.v1.yaml
@@ -6,6 +6,8 @@ properties:
         type: string
         enum:
           - section
+    id:
+        $ref: ../misc/html-id.v1.yaml
     title:
         title: Text
         type: string

--- a/src/model/article-vor.v1.yaml
+++ b/src/model/article-vor.v1.yaml
@@ -26,7 +26,10 @@ allOf:
         body:
             type: array
             items:
-                $ref: ../blocks/section.v1.yaml
+                allOf:
+                  - $ref: ../blocks/section.v1.yaml
+                  - required:
+                      - id
             minItems: 1
         decisionLetter:
             type: object

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -302,6 +302,7 @@
     "body": [
         {
             "type": "section",
+            "id": "s-1",
             "title": "Introduction",
             "content": [
                 {
@@ -399,6 +400,7 @@
         },
         {
             "type": "section",
+            "id": "s-2",
             "title": "Differential diagnosis",
             "content": [
                 {

--- a/src/samples/article-vor/v1/minimum.json
+++ b/src/samples/article-vor/v1/minimum.json
@@ -25,6 +25,7 @@
     "body": [
         {
             "type": "section",
+            "id": "s-1",
             "title": "Introduction",
             "content": [
                 {


### PR DESCRIPTION
This adds an optional ID to `section` blocks, but makes it required for immediate article sections.
