### PR TITLE
Ignoring often-rebuilt dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.puli/
 /composer.lock
+/dist/
 /node_modules/
 /vendor/


### PR DESCRIPTION
See also https://github.com/elifesciences/elife-jenkins-workflow-libs/commit/61739b81510d1207d147dc7f158bd40b1ad8e1f4 that forces files there to be added when Alfred regenerates it

/cc @lsh-0
