### PR TITLE
Remove erroneous date requirements

### DIFF
--- a/src/model/article-history.v1.yaml
+++ b/src/model/article-history.v1.yaml
@@ -35,6 +35,4 @@ dependencies:
     accepted:
       - received
 required:
-    - received
-    - accepted
     - versions

--- a/src/samples/article-history/v1/minimum.json
+++ b/src/samples/article-history/v1/minimum.json
@@ -1,6 +1,4 @@
 {
-    "received": "2015-12-29",
-    "accepted": "2016-03-27",
     "versions": [
         {"status": "vor", "version": 1, "published": "2015-09-01T23:59:00Z"}
     ] 


### PR DESCRIPTION
#70 made the received and accepted dates required, but we don't always have these for Magazine articles.
