### PR TITLE
Proposal: stick to one format for date-time time-offset

### DIFF
--- a/src/samples/collection/v1/complete.json
+++ b/src/samples/collection/v1/complete.json
@@ -74,8 +74,8 @@
             "doi": "10.7554/eLife.09560",
             "authorLine": "Lee R Berger et al",
             "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
-            "published": "2015-09-10T00:00:00Z",
-            "statusDate": "2015-09-10T00:00:00Z",
+            "published": "2015-09-10T00:00:00+00:00",
+            "statusDate": "2015-09-10T00:00:00+00:00",
             "volume": 4,
             "elocationId": "e09560",
             "pdf": "https://elifesciences.org/content/4/e09560.pdf",
@@ -138,8 +138,8 @@
             "doi": "10.7554/eLife.14107",
             "authorLine": "Yongjian Huang et al",
             "title": "Molecular basis for multimerization in the activation of the epidermal growth factor",
-            "published": "2016-03-28T00:00:00Z",
-            "statusDate": "2016-03-28T00:00:00Z",
+            "published": "2016-03-28T00:00:00+00:00",
+            "statusDate": "2016-03-28T00:00:00+00:00",
             "volume": 5,
             "elocationId": "e14107"
         }


### PR DESCRIPTION
[https://www.ietf.org/rfc/rfc3339.txt|RFC 3339] allows two formats for
the time-offset of a UTC date-time:
- `Z`
- `+00:00`
  I could not find a functional difference between the two.

However, it would cause less confusion down the road if we stick to one
of these formats. PHP's `datetime` extension using `DATE_ATOM` as a
format produces `+00:00`, so I would choose that.

Immediate advantage: PHP code in tests can generate exactly these
JSON samples, rather than dumping slightly different strings for
`date-time` fields.

The diff is just a sample, but it would be easy enough to complete it
with `s/00Z/00+00:00/g` on `src/samples/`.
