### PR TITLE
ELPP-1652 Add funding

### DIFF
--- a/src/misc/funding.v1.yaml
+++ b/src/misc/funding.v1.yaml
@@ -1,0 +1,58 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Funding
+type: object
+properties:
+    awards:
+        type: array
+        items:
+            type: object
+            properties:
+                id:
+                    $ref: ../misc/html-id.v1.yaml
+                source:
+                    allOf:
+                      - $ref: ../misc/place.v1.yaml
+                      - properties:
+                            funderId:
+                                $ref: ../misc/doi.v1.yaml
+                awardId:
+                    type: string
+                    minLength: 1
+                recipients:
+                    type: array
+                    items:
+                        oneOf:
+                          - allOf:
+                              - type: object
+                                properties:
+                                    type:
+                                        type: string
+                                        enum:
+                                          - person
+                                required:
+                                  - type
+                              - $ref: ../misc/person.v1.yaml
+                          - type: object
+                            properties:
+                                type:
+                                    type: string
+                                    enum:
+                                      - group
+                                name:
+                                    type: string
+                                    minLength: 1
+                            required:
+                              - type
+                              - name
+                    minItems: 1
+            required:
+              - id
+              - source
+              - recipients
+        minItems: 1
+    statement:
+        type: string
+        minLength: 1
+required:
+  - awards
+  - statement

--- a/src/model/article-vor.v1.yaml
+++ b/src/model/article-vor.v1.yaml
@@ -79,6 +79,8 @@ allOf:
             items:
                 $ref: ../blocks/paragraph.v1.yaml
             minItems: 1
+        funding:
+            $ref: ../misc/funding.v1.yaml
         decisionLetter:
             type: object
             properties:

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -1507,6 +1507,44 @@
             "text": "Animal subjects: If there were animal subjects involved in the study the approval number for the research along with protocol approval would be listed here."
         }
     ],
+    "funding": {
+        "awards": [
+            {
+                "id": "par-1",
+                "source": {
+                    "funderId": "10.13039/501100001659",
+                    "name": [
+                        "Deutsche Forschungsgemeinschaft"
+                    ]
+                },
+                "awardId": "SCHE 1575/3-1",
+                "recipients": [
+                    {
+                        "type": "person",
+                        "name": {
+                            "preferred": "Lee R Berger",
+                            "index": "Berger, Lee R"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "par-3",
+                "source": {
+                    "name": [
+                        "Bundesministerium für Bildung und Forschung"
+                    ]
+                },
+                "recipients": [
+                    {
+                        "type": "group",
+                        "name": "Naledi group"
+                    }
+                ]
+            }
+        ],
+        "statement": "The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+    },
     "decisionLetter": {
         "doi": "10.7554/eLife.09560.030",
         "description": [


### PR DESCRIPTION
Note there's no link between funding recipients and authors. Since we don't do anything with this I think it's ok to lose it, but as soon as we introduce author IDs we can use them instead.