### PR TITLE
Sections may not have empty titles

### DIFF
--- a/src/blocks/section.v1.yaml
+++ b/src/blocks/section.v1.yaml
@@ -11,6 +11,7 @@ properties:
     title:
         title: Text
         type: string
+        minLength: 1
     content:
         description: Content
         type: array


### PR DESCRIPTION
Journal asserts this:
```
[2016-11-24 11:52:05] request.CRITICAL: Uncaught PHP Exception
Assert\InvalidArgumentException: "Value "" is blank, but was expected to
contain a value." at
/srv/journal/vendor/beberlei/assert/lib/Assert/Assertion.php line 220
{"exception":"[object] (Assert\\InvalidArgumentException(code: 27):
Value \"\" is blank, but was expected to contain a value. at
/srv/journal/vendor/beberlei/assert/lib/Assert/Assertion.php:220)
[stacktrace]
Assert\\Assertion::createException('', 'Value \"\" is bla...', 27, NULL)
/srv/journal/vendor/elife/patterns/src/ViewModel/ArticleSection.php(38):
Assert\\Assertion::notBlank('')
/srv/journal/vendor/elife/patterns/src/ViewModel/ArticleSection.php(82):
eLife\\Patterns\\ViewModel\\ArticleSection->__construct('phantom-s-12',
NULL, '', 2, '<p><b>Related r...', false, true, false)
eLife\\Patterns\\ViewModel\\ArticleSection::collapsible('phantom-s-12',
'', 2, '<p><b>Related r...', false, false)

```
so we should check it at this level?