### PR TITLE
Forces images URLs to end with a good extension

### DIFF
--- a/src/blocks/image.v1.yaml
+++ b/src/blocks/image.v1.yaml
@@ -46,7 +46,7 @@ definitions:
                 title: Image URI
                 type: string
                 format: uri
-                pattern: ^https://
+                pattern: ^https://.*\.(tif|jpg)
             attribution:
                 title: Attribution
                 type: array

--- a/src/blocks/image.v1.yaml
+++ b/src/blocks/image.v1.yaml
@@ -46,7 +46,7 @@ definitions:
                 title: Image URI
                 type: string
                 format: uri
-                pattern: ^https://.*\.(tif|jpg|png)
+                pattern: ^https://.*\.(tif|jpg|png|gif)
             attribution:
                 title: Attribution
                 type: array

--- a/src/blocks/image.v1.yaml
+++ b/src/blocks/image.v1.yaml
@@ -46,7 +46,7 @@ definitions:
                 title: Image URI
                 type: string
                 format: uri
-                pattern: ^https://.*\.(tif|jpg)
+                pattern: ^https://.*\.(tif|jpg|png)
             attribution:
                 title: Attribution
                 type: array

--- a/src/blocks/video.v1.yaml
+++ b/src/blocks/video.v1.yaml
@@ -46,7 +46,7 @@ properties:
         title: Image URI
         type: string
         format: uri
-        pattern: ^https://.*\.(tif|jpg)
+        pattern: ^https://.*\.(tif|jpg|png)
     width:
         title: Width
         type: integer

--- a/src/blocks/video.v1.yaml
+++ b/src/blocks/video.v1.yaml
@@ -46,7 +46,7 @@ properties:
         title: Image URI
         type: string
         format: uri
-        pattern: ^https://
+        pattern: ^https://.*\.(tif|jpg)
     width:
         title: Width
         type: integer

--- a/src/blocks/video.v1.yaml
+++ b/src/blocks/video.v1.yaml
@@ -46,7 +46,7 @@ properties:
         title: Image URI
         type: string
         format: uri
-        pattern: ^https://.*\.(tif|jpg|png)
+        pattern: ^https://.*\.(tif|jpg|png|gif)
     width:
         title: Width
         type: integer

--- a/src/misc/image-banner.v1.yaml
+++ b/src/misc/image-banner.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 2:1 crop at 900px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                     1800:
                         title: 2:1 crop at 1800px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                 required:
                   - '900'
                   - '1800'

--- a/src/misc/image-banner.v1.yaml
+++ b/src/misc/image-banner.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 2:1 crop at 900px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                     1800:
                         title: 2:1 crop at 1800px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                 required:
                   - '900'
                   - '1800'

--- a/src/misc/image-banner.v1.yaml
+++ b/src/misc/image-banner.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 2:1 crop at 900px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                     1800:
                         title: 2:1 crop at 1800px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                 required:
                   - '900'
                   - '1800'

--- a/src/misc/image-thumbnail.v1.yaml
+++ b/src/misc/image-thumbnail.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 16:9 crop at 250px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                     500:
                         title: 16:9 crop at 500px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                 required:
                   - '250'
                   - '500'
@@ -32,12 +32,12 @@ properties:
                         title: 1:1 crop at 70px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                     140:
                         title: 1:1 crop at 140px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg)
+                        pattern: ^https://.*\.(tif|jpg|png)
                 required:
                   - '70'
                   - '140'

--- a/src/misc/image-thumbnail.v1.yaml
+++ b/src/misc/image-thumbnail.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 16:9 crop at 250px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                     500:
                         title: 16:9 crop at 500px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                 required:
                   - '250'
                   - '500'
@@ -32,12 +32,12 @@ properties:
                         title: 1:1 crop at 70px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                     140:
                         title: 1:1 crop at 140px width
                         type: string
                         format: uri
-                        pattern: ^https://.*\.(tif|jpg|png)
+                        pattern: ^https://.*\.(tif|jpg|png|gif)
                 required:
                   - '70'
                   - '140'

--- a/src/misc/image-thumbnail.v1.yaml
+++ b/src/misc/image-thumbnail.v1.yaml
@@ -16,12 +16,12 @@ properties:
                         title: 16:9 crop at 250px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                     500:
                         title: 16:9 crop at 500px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                 required:
                   - '250'
                   - '500'
@@ -32,12 +32,12 @@ properties:
                         title: 1:1 crop at 70px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                     140:
                         title: 1:1 crop at 140px width
                         type: string
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https://.*\.(tif|jpg)
                 required:
                   - '70'
                   - '140'

--- a/src/samples/annual-report-list/v1/populated.json
+++ b/src/samples/annual-report-list/v1/populated.json
@@ -10,12 +10,12 @@
                 "alt": "",
                 "sizes": {
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }
@@ -28,12 +28,12 @@
                 "alt": "",
                 "sizes": {
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }

--- a/src/samples/annual-report/v1/complete.json
+++ b/src/samples/annual-report/v1/complete.json
@@ -7,12 +7,12 @@
         "alt": "",
         "sizes": {
             "16:9": {
-                "250": "https://placehold.it/250x141",
-                "500": "https://placehold.it/500x281"
+                "250": "https://placehold.it/250x141.jpg",
+                "500": "https://placehold.it/500x281.jpg"
             },
             "1:1": {
-                "70": "https://placehold.it/70x70",
-                "140": "https://placehold.it/140x140"
+                "70": "https://placehold.it/70x70.jpg",
+                "140": "https://placehold.it/140x140.jpg"
             }
         }
     }

--- a/src/samples/annual-report/v1/minimum.json
+++ b/src/samples/annual-report/v1/minimum.json
@@ -6,12 +6,12 @@
         "alt": "",
         "sizes": {
             "16:9": {
-                "250": "https://placehold.it/250x141",
-                "500": "https://placehold.it/500x281"
+                "250": "https://placehold.it/250x141.jpg",
+                "500": "https://placehold.it/500x281.jpg"
             },
             "1:1": {
-                "70": "https://placehold.it/70x70",
-                "140": "https://placehold.it/140x140"
+                "70": "https://placehold.it/70x70.jpg",
+                "140": "https://placehold.it/140x140.jpg"
             }
         }
     }

--- a/src/samples/article-list/v1/first-page.json
+++ b/src/samples/article-list/v1/first-page.json
@@ -41,12 +41,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/article-list/v1/unpublished-first-page.json
+++ b/src/samples/article-list/v1/unpublished-first-page.json
@@ -35,16 +35,16 @@
                 "alt": "",
                 "sizes": {
                     "2:1": {
-                        "900": "https://placehold.it/900x450",
-                        "1800": "https://placehold.it/1800x900"
+                        "900": "https://placehold.it/900x450.jpg",
+                        "1800": "https://placehold.it/1800x900.jpg"
                     },
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -334,12 +334,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -371,12 +371,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -389,8 +389,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -398,12 +398,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/article-vor/v1/unpublished-complete.json
+++ b/src/samples/article-vor/v1/unpublished-complete.json
@@ -326,12 +326,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -363,12 +363,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -381,8 +381,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -390,12 +390,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/collection-list/v1/first-page.json
+++ b/src/samples/collection-list/v1/first-page.json
@@ -10,12 +10,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/collection/v1/complete.json
+++ b/src/samples/collection/v1/complete.json
@@ -9,8 +9,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -18,12 +18,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }
@@ -92,12 +92,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -156,12 +156,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/collection/v1/minimum.json
+++ b/src/samples/collection/v1/minimum.json
@@ -7,8 +7,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -16,12 +16,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/community-list/v1/first-page.json
+++ b/src/samples/community-list/v1/first-page.json
@@ -41,12 +41,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -75,12 +75,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -96,12 +96,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -132,12 +132,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/labs-experiment-list/v1/first-page.json
+++ b/src/samples/labs-experiment-list/v1/first-page.json
@@ -10,12 +10,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/labs-experiment/v1/complete.json
+++ b/src/samples/labs-experiment/v1/complete.json
@@ -8,8 +8,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -17,12 +17,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/labs-experiment/v1/minimum.json
+++ b/src/samples/labs-experiment/v1/minimum.json
@@ -7,8 +7,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -16,12 +16,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/medium-article-list/v1/first-page.json
+++ b/src/samples/medium-article-list/v1/first-page.json
@@ -10,12 +10,12 @@
                 "alt": "",
                 "sizes": {
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }
@@ -28,12 +28,12 @@
                 "alt": "",
                 "sizes": {
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }

--- a/src/samples/person-list/v1/first-page.json
+++ b/src/samples/person-list/v1/first-page.json
@@ -21,12 +21,12 @@
                 "alt": "",
                 "sizes": {
                     "16:9": {
-                        "250": "https://placehold.it/250x141",
-                        "500": "https://placehold.it/500x281"
+                        "250": "https://placehold.it/250x141.jpg",
+                        "500": "https://placehold.it/500x281.jpg"
                     },
                     "1:1": {
-                        "70": "https://placehold.it/70x70",
-                        "140": "https://placehold.it/140x140"
+                        "70": "https://placehold.it/70x70.jpg",
+                        "140": "https://placehold.it/140x140.jpg"
                     }
                 }
             }

--- a/src/samples/person/v1/complete.json
+++ b/src/samples/person/v1/complete.json
@@ -41,12 +41,12 @@
         "alt": "",
         "sizes": {
             "16:9": {
-                "250": "https://placehold.it/250x141",
-                "500": "https://placehold.it/500x281"
+                "250": "https://placehold.it/250x141.jpg",
+                "500": "https://placehold.it/500x281.jpg"
             },
             "1:1": {
-                "70": "https://placehold.it/70x70",
-                "140": "https://placehold.it/140x140"
+                "70": "https://placehold.it/70x70.jpg",
+                "140": "https://placehold.it/140x140.jpg"
             }
         }
     }

--- a/src/samples/podcast-episode-list/v1/first-page.json
+++ b/src/samples/podcast-episode-list/v1/first-page.json
@@ -10,12 +10,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -36,12 +36,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/podcast-episode/v1/complete.json
+++ b/src/samples/podcast-episode/v1/complete.json
@@ -8,8 +8,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -17,12 +17,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }
@@ -80,12 +80,12 @@
                             "alt": "",
                             "sizes": {
                                 "16:9": {
-                                    "250": "https://placehold.it/250x141",
-                                    "500": "https://placehold.it/500x281"
+                                    "250": "https://placehold.it/250x141.jpg",
+                                    "500": "https://placehold.it/500x281.jpg"
                                 },
                                 "1:1": {
-                                    "70": "https://placehold.it/70x70",
-                                    "140": "https://placehold.it/140x140"
+                                    "70": "https://placehold.it/70x70.jpg",
+                                    "140": "https://placehold.it/140x140.jpg"
                                 }
                             }
                         }
@@ -119,12 +119,12 @@
                             "alt": "",
                             "sizes": {
                                 "16:9": {
-                                    "250": "https://placehold.it/250x141",
-                                    "500": "https://placehold.it/500x281"
+                                    "250": "https://placehold.it/250x141.jpg",
+                                    "500": "https://placehold.it/500x281.jpg"
                                 },
                                 "1:1": {
-                                    "70": "https://placehold.it/70x70",
-                                    "140": "https://placehold.it/140x140"
+                                    "70": "https://placehold.it/70x70.jpg",
+                                    "140": "https://placehold.it/140x140.jpg"
                                 }
                             }
                         }
@@ -140,12 +140,12 @@
                             "alt": "",
                             "sizes": {
                                 "16:9": {
-                                    "250": "https://placehold.it/250x141",
-                                    "500": "https://placehold.it/500x281"
+                                    "250": "https://placehold.it/250x141.jpg",
+                                    "500": "https://placehold.it/500x281.jpg"
                                 },
                                 "1:1": {
-                                    "70": "https://placehold.it/70x70",
-                                    "140": "https://placehold.it/140x140"
+                                    "70": "https://placehold.it/70x70.jpg",
+                                    "140": "https://placehold.it/140x140.jpg"
                                 }
                             }
                         }

--- a/src/samples/podcast-episode/v1/minimum.json
+++ b/src/samples/podcast-episode/v1/minimum.json
@@ -7,8 +7,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -16,12 +16,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }

--- a/src/samples/recommendations/v1/first-page.json
+++ b/src/samples/recommendations/v1/first-page.json
@@ -41,12 +41,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -73,12 +73,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -100,12 +100,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/search/v1/first-page.json
+++ b/src/samples/search/v1/first-page.json
@@ -42,12 +42,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -76,12 +76,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -97,12 +97,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }
@@ -133,12 +133,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/subject-list/v1/first-page.json
+++ b/src/samples/subject-list/v1/first-page.json
@@ -10,8 +10,8 @@
                     "alt": "",
                     "sizes": {
                         "2:1": {
-                            "900": "https://placehold.it/900x450",
-                            "1800": "https://placehold.it/1800x900"
+                            "900": "https://placehold.it/900x450.jpg",
+                            "1800": "https://placehold.it/1800x900.jpg"
                         }
                     }
                 },
@@ -19,12 +19,12 @@
                     "alt": "",
                     "sizes": {
                         "16:9": {
-                            "250": "https://placehold.it/250x141",
-                            "500": "https://placehold.it/500x281"
+                            "250": "https://placehold.it/250x141.jpg",
+                            "500": "https://placehold.it/500x281.jpg"
                         },
                         "1:1": {
-                            "70": "https://placehold.it/70x70",
-                            "140": "https://placehold.it/140x140"
+                            "70": "https://placehold.it/70x70.jpg",
+                            "140": "https://placehold.it/140x140.jpg"
                         }
                     }
                 }

--- a/src/samples/subject/v1/complete.json
+++ b/src/samples/subject/v1/complete.json
@@ -7,8 +7,8 @@
             "alt": "",
             "sizes": {
                 "2:1": {
-                    "900": "https://placehold.it/900x450",
-                    "1800": "https://placehold.it/1800x900"
+                    "900": "https://placehold.it/900x450.jpg",
+                    "1800": "https://placehold.it/1800x900.jpg"
                 }
             }
         },
@@ -16,12 +16,12 @@
             "alt": "",
             "sizes": {
                 "16:9": {
-                    "250": "https://placehold.it/250x141",
-                    "500": "https://placehold.it/500x281"
+                    "250": "https://placehold.it/250x141.jpg",
+                    "500": "https://placehold.it/500x281.jpg"
                 },
                 "1:1": {
-                    "70": "https://placehold.it/70x70",
-                    "140": "https://placehold.it/140x140"
+                    "70": "https://placehold.it/70x70.jpg",
+                    "140": "https://placehold.it/140x140.jpg"
                 }
             }
         }


### PR DESCRIPTION
I got all the ones that were already forced to be starting with `https://`