### PR TITLE
ELPP-2032 Allow basic tables in captions

### DIFF
--- a/src/misc/asset.v1.yaml
+++ b/src/misc/asset.v1.yaml
@@ -21,6 +21,15 @@ properties:
             oneOf:
               - $ref: ../blocks/mathml.v1.yaml
               - $ref: ../blocks/paragraph.v1.yaml
+              - allOf:
+                  - $ref: ../blocks/table.v1.yaml
+                  - properties:
+                        title:
+                            not: {}
+                        sourceData:
+                            not: {}
+                        doi:
+                            not: {}
         minItems: 1
 dependencies:
     caption: [title]

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -464,6 +464,12 @@
                             "id": "eqn1",
                             "label": "[1]",
                             "mathml": "<math>\n<mrow><msub><mtext>e</mtext><mn>0</mn></msub><mo>=</mo><mfrac><mrow><msub><mtext>e</mtext><mrow><mn>0</mn><mo>,</mo><mtext>max</mtext></mrow></msub><mo>×</mo><mtext>GDP</mtext></mrow><mrow><mtext>GDP</mtext><mo>+</mo><msub><mtext>K</mtext><mrow><mtext>inc</mtext></mrow></msub></mrow></mfrac><mo>,</mo></mrow></math>"
+                        },
+                        {
+                            "type": "table",
+                            "tables": [
+                                "<table><thead><tr><th>Names of scaffold</th><th>Chromosome preparation 1</th><th>…</th><th>Chromosome preparation n</th></tr></thead><tbody><tr><td>scaffold 1</td><td>Number of reads associated with the scaffold and preparation</td><td>…</td><td>…</td></tr><tr><td>…</td><td>…</td><td>…</td><td>…</td></tr><tr><td>Scaffold n</td><td>…</td><td>…</td><td>…</td></tr></tbody></table>"
+                            ]
                         }
                     ],
                     "alt": "",


### PR DESCRIPTION
I've disallowed some properties to force the table to a minimum.

This also then won't trigger a figure viewer inside a figure viewer (#99 would solve this, but these tables should probably be caption-less anyway).

/cc @gnott 