### PR TITLE
Simplify tables in captions

### DIFF
--- a/src/misc/asset.v1.yaml
+++ b/src/misc/asset.v1.yaml
@@ -21,15 +21,19 @@ properties:
             oneOf:
               - $ref: ../blocks/mathml.v1.yaml
               - $ref: ../blocks/paragraph.v1.yaml
-              - allOf:
-                  - $ref: ../blocks/table.v1.yaml
-                  - properties:
-                        title:
-                            not: {}
-                        sourceData:
-                            not: {}
-                        doi:
-                            not: {}
+              - # Simplified table block
+                properties:
+                    type:
+                        type: string
+                        enum:
+                          - table
+                    tables:
+                        type: array
+                        items:
+                            title: HTML table
+                            type: string
+                            pattern: ^<table>[\s\S]+</table>$
+                additionalProperties: false
         minItems: 1
 dependencies:
     caption: [title]


### PR DESCRIPTION
We're currently stuck on a version of the PHP JSON Schema library that gets stuck in an infinite loop (causing https://github.com/elifesciences/api-sdk-php/pull/98 and https://github.com/elifesciences/api-sdk-php/pull/99 to fail). Newer versions of the library handle it correctly, but while we wait for https://github.com/webmozart/json/pull/27 to be merged this simplifies the schema.

Use of `additionalProperties` is problematic, so we haven't been using it, but for this case it's probably ok (especially temporarily, and hopefully can be reverted before 1.0 is locked).