### PR TITLE
Allow IDs on tables in captions

### DIFF
--- a/src/misc/asset.v1.yaml
+++ b/src/misc/asset.v1.yaml
@@ -27,6 +27,8 @@ properties:
                         type: string
                         enum:
                           - table
+                    id:
+                        $ref: html-id.v1.yaml
                     tables:
                         type: array
                         items:

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -468,6 +468,7 @@
                         },
                         {
                             "type": "table",
+                            "id": "tbl1",
                             "tables": [
                                 "<table><thead><tr><th>Names of scaffold</th><th>Chromosome preparation 1</th><th>…</th><th>Chromosome preparation n</th></tr></thead><tbody><tr><td>scaffold 1</td><td>Number of reads associated with the scaffold and preparation</td><td>…</td><td>…</td></tr><tr><td>…</td><td>…</td><td>…</td><td>…</td></tr><tr><td>Scaffold n</td><td>…</td><td>…</td><td>…</td></tr></tbody></table>"
                             ]


### PR DESCRIPTION
#130 reduced the amount of properties allowed in captions in tables, including IDs that are included in the XML. Normally I'd say lose it as nothing references it, and I don't know if we'd be able to support it properly when presenting, but we already allow quite a bit of MathML that have IDs too, and I've no idea if anything's referencing those.

/cc @gnott 