### PR TITLE
ELPP-2095 Add date ranges

### DIFF
--- a/src/api.raml
+++ b/src/api.raml
@@ -149,13 +149,13 @@ traits:
                 example: cell-biology
     dateRanged:
         queryParameters:
-            startDate:
+            start-date:
                 description: |
                     Only include <<resources | !lowercase>> available on or after this date.
                 type: date-only
                 required: false
                 example: 2017-01-02
-            endDate:
+            end-date:
                 description: |
                     Only include <<resources | !lowercase>> available before and on this date.
                 type: date-only

--- a/src/api.raml
+++ b/src/api.raml
@@ -147,6 +147,20 @@ traits:
                 required: false
                 repeat: true
                 example: cell-biology
+    dateRanged:
+        queryParameters:
+            startDate:
+                description: |
+                    Only include <<resources | !lowercase>> available on or after this date.
+                type: date-only
+                required: false
+                example: 2017-01-02
+            endDate:
+                description: |
+                    Only include <<resources | !lowercase>> available before and on this date.
+                type: date-only
+                required: false
+                example: 2017-01-02
 
 /annual-reports:
     type: collection
@@ -534,9 +548,10 @@ traits:
         Covers
     get:
         description: |
-            Get a list of covers.
+            Get a list of covers, sorted by date of the item.
         is:
           - paged: { resources: Covers }
+          - dateRanged: { resources: Covers }
         responses:
             200:
                 description: |
@@ -1094,6 +1109,7 @@ traits:
         is:
           - paged: { resources: Results }
           - subjected: { resources: Results }
+          - dateRanged: { resources: Results }
         queryParameters:
             for:
                 description: |


### PR DESCRIPTION
This add date ranges to `/covers` and `/search`. I've not include times, as we don't need that granularity (we're still talking UTC though).

Having a `endDate` before a `startDate`, or having either in the future, needs to result in a `400 Bad Request` (alongside invalid formats).

Ping @nlisgo, @stephenwf.