### PR TITLE
ELPP-2284 Add published/updated dates to all normal content types

### DIFF
--- a/src/samples/blog-article-list/v1/first-page.json
+++ b/src/samples/blog-article-list/v1/first-page.json
@@ -12,6 +12,7 @@
             "title": "Media coverage: Slime can see",
             "impactStatement": "In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.",
             "published": "2016-07-08T08:33:25Z",
+            "updated": "2016-07-09T08:33:25Z",
             "subjects": [
                 {
                     "id": "biophysics-structural-biology",

--- a/src/samples/blog-article/v1/complete.json
+++ b/src/samples/blog-article/v1/complete.json
@@ -3,6 +3,7 @@
     "title": "Media coverage: Slime can see",
     "impactStatement": "In their research paper – Cyanobacteria use micro-optics to sense light direction – Schuergers et al. reveal how bacterial cells act as the equivalent of a microscopic eyeball or the world’s oldest and smallest camera eye, allowing them to ‘see’.",
     "published": "2016-07-08T08:33:25Z",
+    "updated": "2016-07-09T08:33:25Z",
     "content": [
         {
             "type": "paragraph",

--- a/src/samples/collection-list/v1/first-page.json
+++ b/src/samples/collection-list/v1/first-page.json
@@ -4,6 +4,7 @@
         {
             "id": "1",
             "title": "Tropical disease",
+            "published": "2015-09-16T11:19:26Z",
             "updated": "2015-09-16T11:19:26Z",
             "image": {
                 "thumbnail": {

--- a/src/samples/collection/v1/complete.json
+++ b/src/samples/collection/v1/complete.json
@@ -3,7 +3,8 @@
     "title": "Tropical disease",
     "subTitle": "A selection of papers",
     "impactStatement": "eLife has published papers on many tropical diseases, including malaria, Ebola, leishmaniases, Dengue and African sleeping sickness. The articles below have been selected by eLife editors to give a flavour of the breadth of research on tropical diseases published by the journal.",
-    "updated": "2015-09-16T11:19:26Z",
+    "published": "2015-09-16T11:19:26Z",
+    "updated": "2015-09-17T11:19:26Z",
     "image": {
         "banner": {
             "alt": "",

--- a/src/samples/collection/v1/minimum.json
+++ b/src/samples/collection/v1/minimum.json
@@ -1,7 +1,7 @@
 {
     "id": "1",
     "title": "Tropical disease",
-    "updated": "2015-09-16T11:19:26Z",
+    "published": "2015-09-16T11:19:26Z",
     "image": {
         "banner": {
             "alt": "",

--- a/src/samples/community-list/v1/first-page.json
+++ b/src/samples/community-list/v1/first-page.json
@@ -118,6 +118,7 @@
             "id": "1",
             "title": "Changing peer review in cancer research: a seminar at Fred Hutch",
             "impactStatement": "How eLife is influencing the culture of peer review",
+            "published": "2016-08-01T00:00:00Z",
             "starts": "2016-04-22T20:00:00Z",
             "ends": "2016-04-22T21:00:00Z",
             "timezone": "America/Seattle"
@@ -126,7 +127,7 @@
             "type": "collection",
             "id": "1",
             "title": "Tropical disease",
-            "updated": "2015-09-16T11:19:26Z",
+            "published": "2015-09-16T11:19:26Z",
             "image": {
                 "thumbnail": {
                     "alt": "",

--- a/src/samples/event-list/v1/first-page.json
+++ b/src/samples/event-list/v1/first-page.json
@@ -4,6 +4,7 @@
         {
             "id": "2",
             "title": "eLife Continuum webinar",
+            "published": "2016-08-01T00:00:00Z",
             "starts": "2016-08-04T15:00:00Z",
             "ends": "2016-08-04T16:00:00Z"
         },
@@ -11,6 +12,8 @@
             "id": "1",
             "title": "Changing peer review in cancer research: a seminar at Fred Hutch",
             "impactStatement": "How eLife is influencing the culture of peer review",
+            "published": "2016-08-01T00:00:00Z",
+            "updated": "2016-08-02T00:00:00Z",
             "starts": "2016-04-22T20:00:00Z",
             "ends": "2016-04-22T21:00:00Z",
             "timezone": "America/Seattle"

--- a/src/samples/event/v1/complete.json
+++ b/src/samples/event/v1/complete.json
@@ -2,6 +2,8 @@
     "id": "1",
     "title": "Changing peer review in cancer research: a seminar at Fred Hutch",
     "impactStatement": "How eLife is influencing the culture of peer review",
+    "published": "2016-08-01T00:00:00Z",
+    "updated": "2016-08-02T00:00:00Z",
     "starts": "2016-04-22T20:00:00Z",
     "ends": "2016-04-22T21:00:00Z",
     "timezone": "America/Los_Angeles",

--- a/src/samples/event/v1/minimum.json
+++ b/src/samples/event/v1/minimum.json
@@ -1,6 +1,7 @@
 {
     "id": "2",
     "title": "eLife Continuum webinar",
+    "published": "2016-08-01T00:00:00Z",
     "starts": "2016-08-04T15:00:00Z",
     "ends": "2016-08-04T16:00:00Z",
     "content": [

--- a/src/samples/interview-list/v1/first-page.json
+++ b/src/samples/interview-list/v1/first-page.json
@@ -22,7 +22,8 @@
             },
             "title": "Controlling traffic",
             "impactStatement": "Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.",
-            "published": "2016-01-29T16:22:28Z"
+            "published": "2016-01-29T16:22:28Z",
+            "updated": "2016-01-30T16:22:28Z"
         }
     ]
 }

--- a/src/samples/interview/v1/complete.json
+++ b/src/samples/interview/v1/complete.json
@@ -19,6 +19,7 @@
     "title": "Controlling traffic",
     "impactStatement": "Ramanath Hegde is a Postdoctoral Fellow at the Institute of Protein Biochemistry in Naples, Italy, where he investigates ways of preventing cells from destroying mutant proteins.",
     "published": "2016-01-29T16:22:28Z",
+    "updated": "2016-01-29T16:22:28Z",
     "content": [
         {
             "type": "question",

--- a/src/samples/labs-experiment-list/v1/first-page.json
+++ b/src/samples/labs-experiment-list/v1/first-page.json
@@ -5,6 +5,7 @@
             "number": 1,
             "title": "Experimental eLife Lens search page",
             "published": "2015-04-01T11:32:47Z",
+            "updated": "2015-04-01T11:32:47Z",
             "image": {
                 "thumbnail": {
                     "alt": "",

--- a/src/samples/labs-experiment/v1/complete.json
+++ b/src/samples/labs-experiment/v1/complete.json
@@ -3,6 +3,7 @@
     "title": "Experimental eLife Lens search page",
     "impactStatement": "Today on eLife Labs we are launching a small demo of a search interface that brings together some elements of eLife Lens and some of the native power of a technology called elasticsearch. Head over to the demo to try it out now.",
     "published": "2015-04-01T11:32:47Z",
+    "updated": "2015-04-02T11:32:47Z",
     "image": {
         "banner": {
             "alt": "",

--- a/src/samples/podcast-episode-list/v1/first-page.json
+++ b/src/samples/podcast-episode-list/v1/first-page.json
@@ -5,6 +5,7 @@
             "number": 29,
             "title": "April/May 2016",
             "published": "2016-05-27T13:19:42Z",
+            "updated": "2016-05-28T13:19:42Z",
             "image": {
                 "thumbnail": {
                     "alt": "",

--- a/src/samples/podcast-episode/v1/complete.json
+++ b/src/samples/podcast-episode/v1/complete.json
@@ -3,6 +3,7 @@
     "title": "July 2016",
     "impactStatement": "In this episode of the eLife podcast we hear about drug production, early career researchers, honeybees, human migrations and pain.",
     "published": "2016-07-01T08:30:15Z",
+    "updated": "2016-07-02T08:30:15Z",
     "image": {
         "banner": {
             "alt": "",
@@ -134,6 +135,7 @@
                     "type": "collection",
                     "id": "1",
                     "title": "Tropical disease",
+                    "published": "2015-09-16T11:19:26Z",
                     "updated": "2015-09-16T11:19:26Z",
                     "image": {
                         "thumbnail": {

--- a/src/samples/press-package-list/v1/first-page.json
+++ b/src/samples/press-package-list/v1/first-page.json
@@ -12,6 +12,7 @@
             "title": "Females react differently than males to social isolation",
             "impactStatement": "While male and female mice have similar responses to physical stress, research from the Hotchkiss Brain Institute at the University of Calgary, Canada, suggests females, not males, feel stressed when alone.",
             "published": "2016-10-11T17:00:00Z",
+            "updated": "2016-10-11T17:00:00Z",
             "subjects": [
                 {
                     "id": "neuroscience",

--- a/src/samples/press-package/v1/complete.json
+++ b/src/samples/press-package/v1/complete.json
@@ -3,6 +3,7 @@
     "title": "Females react differently than males to social isolation",
     "impactStatement": "While male and female mice have similar responses to physical stress, research from the Hotchkiss Brain Institute at the University of Calgary, Canada, suggests females, not males, feel stressed when alone.",
     "published": "2016-10-11T17:00:00Z",
+    "updated": "2016-10-12T17:00:00Z",
     "content": [
         {
             "type": "paragraph",

--- a/src/samples/recommendations/v1/first-page.json
+++ b/src/samples/recommendations/v1/first-page.json
@@ -94,6 +94,7 @@
             "type": "collection",
             "id": "1",
             "title": "Tropical disease",
+            "published": "2015-09-16T11:19:26Z",
             "updated": "2015-09-16T11:19:26Z",
             "image": {
                 "thumbnail": {

--- a/src/samples/search/v1/first-page.json
+++ b/src/samples/search/v1/first-page.json
@@ -118,6 +118,7 @@
             "type": "collection",
             "id": "1",
             "title": "Tropical disease",
+            "published": "2015-09-16T11:19:26Z",
             "updated": "2015-09-16T11:19:26Z",
             "image": {
                 "thumbnail": {

--- a/src/snippets/blog-article.v1.yaml
+++ b/src/snippets/blog-article.v1.yaml
@@ -11,7 +11,10 @@ properties:
         description: Description of the article
         type: string
     published:
-        description: Publication date (UTC)
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
         $ref: ../misc/date-time.v1.yaml
     subjects:
         description: Article subjects

--- a/src/snippets/collection.v1.yaml
+++ b/src/snippets/collection.v1.yaml
@@ -10,8 +10,11 @@ properties:
     impactStatement:
         description: Description of the collection
         type: string
+    published:
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
     updated:
-        description: Updated date (UTC)
+        title: Updated date (UTC)
         $ref: ../misc/date-time.v1.yaml
     image:
         type: object
@@ -36,6 +39,6 @@ properties:
 required:
   - id
   - title
-  - updated
+  - published
   - image
   - selectedCurator

--- a/src/snippets/event.v1.yaml
+++ b/src/snippets/event.v1.yaml
@@ -10,6 +10,12 @@ properties:
     impactStatement:
         description: Description of the article
         type: string
+    published:
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
+        $ref: ../misc/date-time.v1.yaml
     starts:
         description: Start date/time (UTC)
         $ref: ../misc/date-time.v1.yaml
@@ -23,5 +29,6 @@ properties:
 required:
   - id
   - title
+  - published
   - starts
   - ends

--- a/src/snippets/interview.v1.yaml
+++ b/src/snippets/interview.v1.yaml
@@ -17,6 +17,9 @@ properties:
     published:
         title: Publication date (UTC)
         $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
+        $ref: ../misc/date-time.v1.yaml
 required:
   - id
   - interviewee

--- a/src/snippets/labs-experiment.v1.yaml
+++ b/src/snippets/labs-experiment.v1.yaml
@@ -13,7 +13,10 @@ properties:
         description: Description of the experiment
         type: string
     published:
-        description: Publication date (UTC)
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
         $ref: ../misc/date-time.v1.yaml
     image:
         type: object

--- a/src/snippets/podcast-episode.v1.yaml
+++ b/src/snippets/podcast-episode.v1.yaml
@@ -13,7 +13,10 @@ properties:
         description: Description of the episode
         type: string
     published:
-        description: Publication date (UTC)
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
         $ref: ../misc/date-time.v1.yaml
     image:
         type: object

--- a/src/snippets/press-package.v1.yaml
+++ b/src/snippets/press-package.v1.yaml
@@ -11,7 +11,10 @@ properties:
         description: Description of the press package
         type: string
     published:
-        description: Publication date (UTC)
+        title: Publication date (UTC)
+        $ref: ../misc/date-time.v1.yaml
+    updated:
+        title: Updated date (UTC)
         $ref: ../misc/date-time.v1.yaml
     subjects:
         description: Press package subjects


### PR DESCRIPTION
For consistency, this adds `published` and `updated` to all normal content types (except articles... though I wonder if `versionDate` should become `updated`).

We need to (usually) order collections by `updated`, but this does change it so `updated` is optional. If it's not present (ie never been updated), `published` would be used. We _could_ have it so `updated` is required, in which case it would be the same as `published`. To tell if something is updated you would have to see if they're the same, rather than whether `updated` is present.

/cc @nlisgo @stephenwf @giorgiosironi 