### PR TITLE
ELPP-2279 Add use-date parameter

### DIFF
--- a/src/api.raml
+++ b/src/api.raml
@@ -164,6 +164,17 @@ traits:
                 type: date-only
                 required: false
                 example: 2017-01-02
+            use-date:
+                description: |
+                    Which date to use for ordering and filtering.
+
+                    `default` refers to the default date per content type, which may change over time. `published` refers to the original publication date, which does not change.
+                type: string
+                enum:
+                  - default
+                  - published
+                required: false
+                default: default
 
 /annual-reports:
     type: collection


### PR DESCRIPTION
This resolves the archive ordering/filtering problem. I'm not a _huge_ fan of it, but I don't see another way (without creating different end points).

I've added it to the `dateRanged` trait, which is only used by search and covers (the two used by the archive). Ideally this would be applied everywhere, but we can always add it later.

/cc @nlisgo @stephenwf @giorgiosironi 