### PR TITLE
Make periodical a simple string

### DIFF
--- a/src/misc/reference.v1.yaml
+++ b/src/misc/reference.v1.yaml
@@ -285,7 +285,8 @@ allOf:
                 type: string
                 minLength: 1
             periodical:
-                $ref: place.v1.yaml
+                type: string
+                minLength: 1
             volume:
                 type: string
                 minLength: 1

--- a/src/samples/article-vor/v1/complete.json
+++ b/src/samples/article-vor/v1/complete.json
@@ -1043,11 +1043,7 @@
                 }
             ],
             "articleTitle": "Minimal periodical article",
-            "periodical": {
-                "name": [
-                    "A periodical"
-                ]
-            },
+            "periodical": "A periodical",
             "pages": "In press"
         },
         {
@@ -1069,11 +1065,7 @@
             ],
             "authorsEtAl": true,
             "articleTitle": "Complete periodical article",
-            "periodical": {
-                "name": [
-                    "A periodical"
-                ]
-            },
+            "periodical": "A periodical",
             "volume": "Volume 1",
             "pages": {
                 "first": "231",

--- a/src/samples/article-vor/v1/unpublished-complete.json
+++ b/src/samples/article-vor/v1/unpublished-complete.json
@@ -1003,11 +1003,7 @@
                 }
             ],
             "articleTitle": "Minimal periodical article",
-            "periodical": {
-                "name": [
-                    "A periodical"
-                ]
-            },
+            "periodical": "A periodical",
             "pages": "In press"
         },
         {
@@ -1029,11 +1025,7 @@
             ],
             "authorsEtAl": true,
             "articleTitle": "Complete periodical article",
-            "periodical": {
-                "name": [
-                    "A periodical"
-                ]
-            },
+            "periodical": "A periodical",
             "volume": "Volume 1",
             "pages": {
                 "first": "231",


### PR DESCRIPTION
Following on from #145, the same should apply to periodical names.

/cc @gnott 