### PR TITLE
Prevent multiple builds with the same commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ elifeLibrary {
 
     elifeMainlineOnly {
         stage 'Committing'
-        elifeGitAutoCommit "Regenerated dist/", "dist/"
+        def isThereANewCommit = elifeGitAutoCommit "Regenerated dist/", "dist/"
         def commit = elifeGitRevision()
 
         stage 'Pushing to alfred/regeneration_of_dist'
@@ -31,6 +31,10 @@ elifeLibrary {
         elifeGitMoveToBranch commit, 'master'
 
         stage 'Downstream'
-        build job: 'dependencies-bot-lax-adaptor-update-api-raml', wait: false
+        if (isThereANewCommit) {
+            build job: 'dependencies-bot-lax-adaptor-update-api-raml', wait: false
+        } else {
+            echo "Nothing to do, latest commit is old"
+        }
     }
 }


### PR DESCRIPTION
While the bot-lax-adaptor only picks from the `master` branch and that is safe, we don't want the updates to be triggered twice.