### PR TITLE
ELPP-2861 Add optional pdf property to annual report

### DIFF
--- a/src/model/annual-report.v1.yaml
+++ b/src/model/annual-report.v1.yaml
@@ -10,6 +10,9 @@ properties:
         description: Annual report URI
         type: string
         format: uri
+    pdf:
+        type: string
+        format: uri
     title:
         description: Title
         type: string

--- a/src/samples/annual-report-list/v1/populated.json
+++ b/src/samples/annual-report-list/v1/populated.json
@@ -27,6 +27,7 @@
         {
             "year": 2013,
             "uri": "http://2013.elifesciences.org/",
+            "pdf": "http://digest-pictures-200814.s3.amazonaws.com/JN2492%20eLife%202013%20A4.pdf",
             "title": "The eLife Sciences 2013 Annual Report",
             "image": {
                 "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig1-v1.tif",

--- a/src/samples/annual-report/v1/complete.json
+++ b/src/samples/annual-report/v1/complete.json
@@ -1,6 +1,7 @@
 {
     "year": 2014,
     "uri": "http://2014.elifesciences.org/",
+    "pdf": "https://2014.elifesciences.org/assets/elife-annual-report-2014.pdf",
     "title": "The eLife Sciences 2014 Annual Report",
     "impactStatement": "Having published almost 800 research articles by the close of 2014, in this report eLife is showcasing its achievements in attracting growing numbers of submissions, publishing a broad swath of high-quality research swiftly and constructively, supporting transparency and reproducibility, as well as the careers of early-career researchers, and exploring new publication formats.",
     "image": {


### PR DESCRIPTION
The design of the annual reports listing page allows for the pdf link to appear below the impact statement.