### PR TITLE
Podcast episodes containing

### DIFF
--- a/src/api.raml
+++ b/src/api.raml
@@ -176,7 +176,7 @@ traits:
                   - published
                 required: false
                 default: default
-    contained:
+    container:
         queryParameters:
           containing[]:
               description: |
@@ -505,7 +505,7 @@ traits:
         is:
           - paged: { resources: Collections }
           - subjected: { resources: Collections }
-          - contained: { resources: Collections }
+          - container: { resources: Collections }
         responses:
             200:
                 description: |
@@ -1039,7 +1039,7 @@ traits:
             Get a list of episodes, sorted by number.
         is:
           - paged: { resources: Episodes }
-          - contained: { resources: Episodes }
+          - container: { resources: Episodes }
         responses:
             200:
                 description: |

--- a/src/api.raml
+++ b/src/api.raml
@@ -176,6 +176,14 @@ traits:
                   - published
                 required: false
                 default: default
+    contained:
+        queryParameters:
+          containing[]:
+              description: |
+                  Only return <<resources | !lowercase>> containing at least one of these items.
+              type: string[]
+              required: false
+              example: [article/1234, interview/5678]
 
 /annual-reports:
     type: collection
@@ -497,13 +505,7 @@ traits:
         is:
           - paged: { resources: Collections }
           - subjected: { resources: Collections }
-        queryParameters:
-            containing[]:
-                description: |
-                    Only return collections containing at least one of these items.
-                type: string[]
-                required: false
-                example: [article/1234, interview/5678]
+          - contained: { resources: Collections }
         responses:
             200:
                 description: |
@@ -1037,6 +1039,7 @@ traits:
             Get a list of episodes, sorted by number.
         is:
           - paged: { resources: Episodes }
+          - contained: { resources: Episodes }
         responses:
             200:
                 description: |


### PR DESCRIPTION
Allows https://github.com/elifesciences/recommendations/pull/83 to include podcast episodes.

(Technically it wants the _chapters_, but until we add an endpoint for chapters this will do.)