### PR TITLE
Fetch explicitly develop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ elifeLibrary {
 
     elifePullRequestOnly {
         stage 'Checking dist/'
+        sh 'git remote -v'
+        sh 'git branch -a'
         sh 'git fetch && git diff --exit-code origin/develop...HEAD dist/'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,7 @@ elifeLibrary {
 
     elifePullRequestOnly {
         stage 'Checking dist/'
-        sh 'git remote -v'
-        sh 'git branch -a'
-        sh 'git fetch && git diff --exit-code origin/develop...HEAD dist/'
+        sh 'git fetch origin develop:refs/remotes/origin/develop && git diff --exit-code origin/develop...HEAD dist/'
     }
 
     stage 'Compiling'


### PR DESCRIPTION
Due to a Jenkins change, we want to explicitly fetch the remote `develop` branch rather than reluying on the current repository configuration to make it available.