### PR TITLE
Make api-raml JSON schemas available as python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include py_api_raml/*.json
+include dist/model/*.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include py_api_raml/*.json

--- a/compile.js
+++ b/compile.js
@@ -7,13 +7,12 @@ var recursive = require('recursive-readdir');
 var refParser = require('json-schema-ref-parser');
 
 fs.removeSync('./dist');
-fs.removeSync('./py_api_raml'); // for py
+fs.removeSync('./elife_api');
 
 fs.mkdirsSync('./dist/model');
 fs.mkdirsSync('./dist/samples');
 fs.mkdirsSync('./dist/styles');
-
-fs.mkdirsSync('./py_api_raml'); // for py
+fs.mkdirsSync('./elife_api');
 
 recursive('./src/model', function (err, files) {
     var promises = [];
@@ -68,8 +67,6 @@ recursive('./src/model', function (err, files) {
         fs.copy('./src/styles', './dist/styles');
         fs.copy('./src/index.html', './dist/index.html');
         fs.copy('./src/favicon.ico', './dist/favicon.ico');
-
-        fs.copy('./src/__init__.py_base', './py_api_raml/__init__.py'); // for py
-        fs.copy('./dist/model', './py_api_raml'); // for py
+        fs.copy('./src/__init__.py_base', './elife_api/__init__.py');
     });
 });

--- a/compile.js
+++ b/compile.js
@@ -7,9 +7,13 @@ var recursive = require('recursive-readdir');
 var refParser = require('json-schema-ref-parser');
 
 fs.removeSync('./dist');
+fs.removeSync('./py_api_raml'); // for py
+
 fs.mkdirsSync('./dist/model');
 fs.mkdirsSync('./dist/samples');
 fs.mkdirsSync('./dist/styles');
+
+fs.mkdirsSync('./py_api_raml'); // for py
 
 recursive('./src/model', function (err, files) {
     var promises = [];
@@ -64,5 +68,8 @@ recursive('./src/model', function (err, files) {
         fs.copy('./src/styles', './dist/styles');
         fs.copy('./src/index.html', './dist/index.html');
         fs.copy('./src/favicon.ico', './dist/favicon.ico');
+
+        fs.copy('./src/__init__.py_base', './py_api_raml/__init__.py'); // for py
+        fs.copy('./dist/model', './py_api_raml'); // for py
     });
 });

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import elife_api
 setup(
     name='elife_api',
     version=elife_api.__version__,
-    description='Utility for accessing eLife API-Raml JSON schemas in Python.',
+    description='Utility for accessing eLife API JSON Schemas.',
     packages=['elife_api'],
     license='MIT',
     url='https://github.com/elifesciences/api-raml',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup
+
+import elife_api
+
+setup(
+    name='elife_api',
+    version=elife_api.__version__,
+    description='Utility for accessing eLife API-Raml JSON schemas in Python.',
+    packages=['elife_api'],
+    license='MIT',
+    url='https://github.com/elifesciences/api-raml',
+    maintainer='eLife Sciences Publications Ltd.',
+    maintainer_email='py@elifesciences.org',
+    classifiers=[
+        "Development Status :: 1 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        ],
+    include_package_data=True
+)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license='MIT',
     url='https://github.com/elifesciences/api-raml',
     maintainer='eLife Sciences Publications Ltd.',
-    maintainer_email='py@elifesciences.org',
+    maintainer_email='tech-team@elifesciences.org',
     classifiers=[
         "Development Status :: 1 - Alpha",
         "Intended Audience :: Developers",

--- a/src/__init__.py_base
+++ b/src/__init__.py_base
@@ -1,11 +1,11 @@
 import os
 
-import py_api_raml
+import elife_api
 
 __version__ = '0.0.1'
 
 
-schema_directory = os.path.dirname(py_api_raml.__file__)
+schema_directory = os.path.dirname(elife_api.__file__)
 
 
 __all__ = [schema_directory]

--- a/src/__init__.py_base
+++ b/src/__init__.py_base
@@ -1,0 +1,11 @@
+import os
+
+import py_api_raml
+
+__version__ = '0.0.1'
+
+
+schema_directory = os.path.dirname(py_api_raml.__file__)
+
+
+__all__ = [schema_directory]


### PR DESCRIPTION
I have added the required changes to allowing the following functionality to be possible:

`pip install -e git+https://github.com/elifesciences/api-raml.git#egg=api-raml`

```
from py_api_raml import schema_directory
import os

>>> print(schema_directory)
'/Users/someuser/somefolder/api-raml/venv/lib/python3.5/site-packages/py_api_raml-0.0.1-py3.5.egg/py_api_raml'

>>> os.listdir(schema_directory)
['article-poa.v1.json', 'press-package.v3.json', 'article-related.v1.json'.......]
```

The 'schema_directory' string allows you to view the contents of the directory and to also perform actions on the files based on the fact you have their directory path. e.g.

```
file_path = os.path.join(schema_directory, 'article-pop.v1.json')
with open(file_path) as f:
    data = json.load(f)
```

At this point I think keeping it off PyPi will allow for more flexibility. We can still list it as a requirement via its git address and pip will handle it fine. If we created it as a PyPi package we would need to build and re version after each change/build of api-raml.