### PR TITLE
Match sample minimum job advert to schema

### DIFF
--- a/src/samples/job-advert/v1/minimum.json
+++ b/src/samples/job-advert/v1/minimum.json
@@ -1,7 +1,6 @@
 {
     "id": "80000099",
     "title": "Editorial Assistant",
-    "impactStatement": "Support the Executive Editor in delivering an unparalleled editorial process and author experience",
     "published": "2016-10-11T17:00:00Z",
     "closingDate": "2016-10-25T17:00:00Z",
 


### PR DESCRIPTION
Removing `impactStatement` from sample minimum as it's not required in the schema.