### PR TITLE
Tweak error type format

### DIFF
--- a/src/model/error.v1.yaml
+++ b/src/model/error.v1.yaml
@@ -6,8 +6,11 @@ properties:
     type:
         description: A URI reference that identifies the problem type
         type: string
-        format: uri
         default: about:blank
+        oneOf:
+          - enum:
+              - about:blank
+          - format: uri
     title:
         description: A short, human-readable summary of the problem type
         type: string


### PR DESCRIPTION
Some validators don't recognise relative URIs, so `about:blank` is rejected.