### PR TITLE
Use newer block types in job adverts

### DIFF
--- a/src/model/job-advert.v1.yaml
+++ b/src/model/job-advert.v1.yaml
@@ -7,7 +7,7 @@ allOf:
         content:
             type: array
             items:
-                $ref: ../misc/blocks-all.v1.yaml
+                $ref: ../misc/blocks-all.v2.yaml
             minItems: 1
     required:
       - content


### PR DESCRIPTION
Due to the merge timings in #178 and #186, job adverts were not updated for the new block types. The API is still marked as experimental, so it's ok to make this tiny BC break on something that probably won't happen (an advert isn't going to have a figure that has source data).