### PR TITLE
Let annotation parents be optional

### DIFF
--- a/src/model/annotation-list.v1.yaml
+++ b/src/model/annotation-list.v1.yaml
@@ -58,7 +58,6 @@ properties:
             required:
               - id
               - access
-              - parents
               - document
               - created
             anyOf:

--- a/src/samples/annotation-list/v1/first-page.json
+++ b/src/samples/annotation-list/v1/first-page.json
@@ -58,7 +58,6 @@
                 "title": "Molecular basis for multimerization in the activation of the epidermal growth factor",
                 "uri": "https://elifesciences.org/articles/14107"
             },
-            "parents": [],
             "created": "2017-09-15T15:40:52Z",
             "highlight": "clustering are important correlates of EGFR activation"
         },
@@ -69,7 +68,6 @@
                 "title": "Molecular basis for multimerization in the activation of the epidermal growth factor",
                 "uri": "https://elifesciences.org/articles/14107"
             },
-            "parents": [],
             "created": "2017-09-15T16:40:00Z",
             "content": [
                 {


### PR DESCRIPTION
Since some annotations can never have a parent, `parents` should be optional.