### PR TITLE
Rename annotation parents to ancestors

### DIFF
--- a/src/model/annotation-list.v1.yaml
+++ b/src/model/annotation-list.v1.yaml
@@ -18,7 +18,7 @@ properties:
                 access:
                     $ref: ../misc/access-level.v1.yaml
                 ancestors:
-                    description: IDs of previous annotations in this thread
+                    description: IDs of previous annotations in this thread (oldest first)
                     type: array
                     items:
                         type: string

--- a/src/model/annotation-list.v1.yaml
+++ b/src/model/annotation-list.v1.yaml
@@ -17,8 +17,8 @@ properties:
                     type: string
                 access:
                     $ref: ../misc/access-level.v1.yaml
-                parents:
-                    description: Parent annotation IDs
+                ancestors:
+                    description: IDs of previous annotations in this thread
                     type: array
                     items:
                         type: string

--- a/src/samples/annotation-list/v1/first-page.json
+++ b/src/samples/annotation-list/v1/first-page.json
@@ -8,7 +8,7 @@
                 "title": "Molecular basis for multimerization in the activation of the epidermal growth factor",
                 "uri": "https://elifesciences.org/articles/14107"
             },
-            "parents": [
+            "ancestors": [
                 "zwtToOGEEeeN329z_8T-jg",
                 "z2wMhuGEEeekCjfkA_Z1lw"
             ],


### PR DESCRIPTION
Following https://github.com/elifesciences/journal/pull/837#discussion_r163224077.

Annotations will need to be updated to supply both while clients (ie Journal) switch over.