### PR TITLE
ELPP-3196 Add more types to metrics

### DIFF
--- a/src/api.raml
+++ b/src/api.raml
@@ -1163,6 +1163,11 @@ traits:
             type: string
             enum:
               - article
+              - blog-article
+              - event
+              - interview
+              - labs-post
+              - press-package
         id:
             description: |
                 Content ID.
@@ -1176,7 +1181,7 @@ traits:
               - page-views
     get:
         description: |
-            Get a metric for a piece of content
+            Get a metric for a piece of content, by time period if available
         is:
           - paged: { resources: Time periods }
         queryParameters:

--- a/src/api.raml
+++ b/src/api.raml
@@ -1164,6 +1164,7 @@ traits:
             enum:
               - article
               - blog-article
+              - collection
               - event
               - interview
               - labs-post
@@ -1181,7 +1182,7 @@ traits:
               - page-views
     get:
         description: |
-            Get a metric for a piece of content, by time period if available
+            Get a metric for a piece of content
         is:
           - paged: { resources: Time periods }
         queryParameters:


### PR DESCRIPTION
Add more type options to metrics (not every type possible, just those that we need).

We don't need it split by time for these types, but rather than create a separate API we can use the existing one and just return the total in the response if it's simpler to implement. A `metric=downloads` request for these types should also 404.