### PR TITLE
Reduce download size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 /*.* export-ignore
 /adr export-ignore
-/Jenkinsfile export-ignore
+/Jenkinsfile* export-ignore
 /src export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/*.* export-ignore
+/adr export-ignore
+/Jenkinsfile export-ignore
+/src export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /composer.lock
-/dist/
 /node_modules/
 /vendor/


### PR DESCRIPTION
Cut outs things like `src` from download files, which will mean smaller containers elsewhere.