### PR TITLE
Remove abstract from article snippet except in recommendations

### DIFF
--- a/src/misc/abstract.v1.yaml
+++ b/src/misc/abstract.v1.yaml
@@ -1,0 +1,11 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Abstract
+type: object
+properties:
+    content:
+        type: array
+        items:
+            $ref: ../blocks/paragraph.v1.yaml
+        minItems: 1
+required:
+  - content

--- a/src/misc/article.v1.yaml
+++ b/src/misc/article.v1.yaml
@@ -4,6 +4,8 @@ type: object
 allOf:
   - $ref: ../snippets/article.v1.yaml
   - properties:
+        abstract:
+            $ref: abstract.v1.yaml
         issue:
             type: integer
             minimum: 1

--- a/src/misc/article.v2.yaml
+++ b/src/misc/article.v2.yaml
@@ -4,6 +4,8 @@ type: object
 allOf:
   - $ref: ../snippets/article.v1.yaml
   - properties:
+        abstract:
+            $ref: abstract.v1.yaml
         xml:
             type: string
             format: uri

--- a/src/model/article-vor.v1.yaml
+++ b/src/model/article-vor.v1.yaml
@@ -5,6 +5,11 @@ allOf:
   - $ref: ../snippets/article-vor.v1.yaml
   - $ref: ../misc/article.v1.yaml
   - properties:
+        abstract:
+            type: object
+            properties:
+                doi:
+                    $ref: ../misc/doi.v1.yaml
         keywords:
             type: array
             items:

--- a/src/model/article-vor.v2.yaml
+++ b/src/model/article-vor.v2.yaml
@@ -5,6 +5,11 @@ allOf:
   - $ref: ../snippets/article-vor.v1.yaml
   - $ref: ../misc/article.v2.yaml
   - properties:
+        abstract:
+            type: object
+            properties:
+                doi:
+                    $ref: ../misc/doi.v1.yaml
         keywords:
             type: array
             items:

--- a/src/model/article-vor.v3.yaml
+++ b/src/model/article-vor.v3.yaml
@@ -5,6 +5,11 @@ allOf:
   - $ref: ../snippets/article-vor.v1.yaml
   - $ref: ../misc/article.v2.yaml
   - properties:
+        abstract:
+            type: object
+            properties:
+                doi:
+                    $ref: ../misc/doi.v1.yaml
         keywords:
             type: array
             items:

--- a/src/model/recommendations.v1.yaml
+++ b/src/model/recommendations.v1.yaml
@@ -11,8 +11,13 @@ properties:
         type: array
         items:
             oneOf:
-              - $ref: ../snippets/article-poa.v1.yaml
-              - $ref: ../snippets/article-vor.v1.yaml
+              - allOf:
+                  - properties:
+                      abstract:
+                          $ref: ../misc/abstract.v1.yaml
+                  - oneOf:
+                      - $ref: ../snippets/article-poa.v1.yaml
+                      - $ref: ../snippets/article-vor.v1.yaml
               - allOf:
                   - type: object
                     required:

--- a/src/model/recommendations.v1.yaml
+++ b/src/model/recommendations.v1.yaml
@@ -15,9 +15,16 @@ properties:
                   - properties:
                       abstract:
                           $ref: ../misc/abstract.v1.yaml
-                  - oneOf:
-                      - $ref: ../snippets/article-poa.v1.yaml
-                      - $ref: ../snippets/article-vor.v1.yaml
+                  - $ref: ../snippets/article-poa.v1.yaml
+              - allOf:
+                  - properties:
+                      abstract:
+                          allOf:
+                              - properties:
+                                  doi:
+                                      $ref: ../misc/doi.v1.yaml
+                              - $ref: ../misc/abstract.v1.yaml
+                  - $ref: ../snippets/article-vor.v1.yaml
               - allOf:
                   - type: object
                     required:

--- a/src/model/recommendations.v1.yaml
+++ b/src/model/recommendations.v1.yaml
@@ -15,16 +15,13 @@ properties:
                   - properties:
                       abstract:
                           $ref: ../misc/abstract.v1.yaml
-                  - $ref: ../snippets/article-poa.v1.yaml
-              - allOf:
-                  - properties:
-                      abstract:
-                          allOf:
-                              - properties:
-                                  doi:
-                                      $ref: ../misc/doi.v1.yaml
-                              - $ref: ../misc/abstract.v1.yaml
-                  - $ref: ../snippets/article-vor.v1.yaml
+                  - oneOf:
+                      - $ref: ../snippets/article-poa.v1.yaml
+                      - allOf:
+                          - properties:
+                              doi:
+                                  $ref: ../misc/doi.v1.yaml
+                          - $ref: ../snippets/article-vor.v1.yaml
               - allOf:
                   - type: object
                     required:

--- a/src/snippets/article-vor.v1.yaml
+++ b/src/snippets/article-vor.v1.yaml
@@ -14,11 +14,6 @@ allOf:
         figuresPdf:
             type: string
             format: uri
-        abstract:
-            type: object
-            properties:
-                doi:
-                    $ref: ../misc/doi.v1.yaml
         image:
             type: object
             properties:

--- a/src/snippets/article.v1.yaml
+++ b/src/snippets/article.v1.yaml
@@ -80,16 +80,6 @@ properties:
             type: string
             minLength: 1
         uniqueItems: true
-    abstract:
-        type: object
-        properties:
-            content:
-                type: array
-                items:
-                    $ref: ../blocks/paragraph.v1.yaml
-                minItems: 1
-        required:
-          - content
 required:
   - status
   - id


### PR DESCRIPTION
The important removals are found here:
- https://github.com/elifesciences/api-raml/pull/248/files#diff-9e840b084d9f1ea1e0e92abfc57ea327
- https://github.com/elifesciences/api-raml/pull/248/files#diff-badbd555d4ea1d981b262d2b50ab3b4b

Removing the abstract property from the snippets strips the property from all listings. Because the full article models borrow from the snippet then we have to declare the property here:
- https://github.com/elifesciences/api-raml/pull/248/files#diff-88a590b4913ac35e067c01ee1d20d8b0
- https://github.com/elifesciences/api-raml/pull/248/files#diff-0351a4a0208c0ca05d9c16de3cc955f9

As recommendations is the only listing that we need the abstract we can declare the abstract here:
- https://github.com/elifesciences/api-raml/pull/248/files#diff-9340409dc67ddc2522b0fd9c72a99d61