### PR TITLE
Doi social media image

### DIFF
--- a/src/misc/article.v3.yaml
+++ b/src/misc/article.v3.yaml
@@ -4,6 +4,8 @@ type: object
 allOf:
   - $ref: ../snippets/article.v1.yaml
   - properties:
+        socialImage:
+            $ref: image.v1.yaml
         abstract:
             $ref: abstract.v2.yaml
         xml:

--- a/src/samples/article-poa/v3/complete.json
+++ b/src/samples/article-poa/v3/complete.json
@@ -149,8 +149,8 @@
             "filename": "an-image.jpg"
         },
         "size": {
-            "width": 4194,
-            "height": 4714
+            "width": 1772,
+            "height": 1782
         },
         "focalPoint": {
             "x": 25,

--- a/src/samples/article-poa/v3/complete.json
+++ b/src/samples/article-poa/v3/complete.json
@@ -137,6 +137,26 @@
         "Human",
         "Xenopus"
     ],
+    "socialImage": {
+        "uri": "https://iiif.elifesciences.org/lax/14107%2Felife-14107-fig1-v3.tif",
+        "alt": "",
+        "attribution": [
+            "By some person."
+        ],
+        "source": {
+            "mediaType": "image/jpeg",
+            "uri": "https://iiif.elifesciences.org/lax/14107%2Felife-14107-fig1-v3.tif/full/full/0/default.jpg",
+            "filename": "an-image.jpg"
+        },
+        "size": {
+            "width": 4194,
+            "height": 4714
+        },
+        "focalPoint": {
+            "x": 25,
+            "y": 75
+        }
+    },
     "abstract": {
         "content": [
             {

--- a/src/samples/article-vor/v4/complete.json
+++ b/src/samples/article-vor/v4/complete.json
@@ -346,6 +346,26 @@
             }
         }
     },
+    "socialImage": {
+        "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif",
+        "alt": "",
+        "attribution": [
+            "By some person."
+        ],
+        "source": {
+            "mediaType": "image/jpeg",
+            "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif/full/full/0/default.jpg",
+            "filename": "an-image.jpg"
+        },
+        "size": {
+            "width": 4194,
+            "height": 4714
+        },
+        "focalPoint": {
+            "x": 25,
+            "y": 75
+        }
+    },
     "abstract": {
         "doi": "10.7554/eLife.09560.001",
         "content": [


### PR DESCRIPTION
@lsh-0 We would need to expose another article store endpoint similar to `/articles/[articleId]/fragments/image` which would allow us to add, modify or delete an article `socialImage`.

This would need to be available regardless of whether an article was `vor` or `poa`. 

As this new property is optional we shouldn't need to bump versions.