### PR TITLE
Improve the logic of required properties for article image

### DIFF
--- a/src/common/article-vor.v1.yaml
+++ b/src/common/article-vor.v1.yaml
@@ -1,8 +1,8 @@
 $schema: http://json-schema.org/draft-04/schema#
-title: Article VoR snippet (basic)
+title: Article VoR common properties
 type: object
 allOf:
-  - $ref: article.v1.yaml
+  - $ref: ../snippets/article.v1.yaml
   - properties:
         status:
             type: string

--- a/src/model/article-vor.v4.yaml
+++ b/src/model/article-vor.v4.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR
 type: object
 allOf:
-  - $ref: ../snippets/article-vor.v1.yaml
+  - $ref: ../snippets/article-vor-basic.v1.yaml
   - $ref: ../misc/article.v3.yaml
   - properties:
         image:
@@ -11,9 +11,9 @@ allOf:
                     $ref: ../misc/image.v1.yaml
             anyOf:
               - required:
-                 - thumbnail
+                  - thumbnail
               - required:
-                 - social
+                  - social
         abstract:
             type: object
             properties:

--- a/src/model/article-vor.v4.yaml
+++ b/src/model/article-vor.v4.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR
 type: object
 allOf:
-  - $ref: ../snippets/article-vor-basic.v1.yaml
+  - $ref: ../common/article-vor.v1.yaml
   - $ref: ../misc/article.v3.yaml
   - properties:
         image:

--- a/src/snippets/article-vor-basic.v1.yaml
+++ b/src/snippets/article-vor-basic.v1.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Article VoR snippet (basic)
+type: object
+allOf:
+  - $ref: article.v1.yaml
+  - properties:
+        status:
+            type: string
+            enum:
+              - vor
+        impactStatement:
+            type: string
+            minLength: 1
+        figuresPdf:
+            type: string
+            format: uri
+        image:
+            type: object
+            properties:
+                thumbnail:
+                    $ref: ../misc/image.v1.yaml

--- a/src/snippets/article-vor.v1.yaml
+++ b/src/snippets/article-vor.v1.yaml
@@ -2,22 +2,8 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR snippet
 type: object
 allOf:
-  - $ref: article.v1.yaml
+  - $ref: article-vor-basic.v1.yaml
   - properties:
-        status:
-            type: string
-            enum:
-              - vor
-        impactStatement:
-            type: string
-            minLength: 1
-        figuresPdf:
-            type: string
-            format: uri
         image:
-            type: object
-            properties:
-                thumbnail:
-                    $ref: ../misc/image.v1.yaml
             required:
               - thumbnail

--- a/src/snippets/article-vor.v1.yaml
+++ b/src/snippets/article-vor.v1.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Article VoR snippet
 type: object
 allOf:
-  - $ref: article-vor-basic.v1.yaml
+  - $ref: ../common/article-vor.v1.yaml
   - properties:
         image:
             required:

--- a/src/snippets/article-vor.v1.yaml
+++ b/src/snippets/article-vor.v1.yaml
@@ -19,8 +19,5 @@ allOf:
             properties:
                 thumbnail:
                     $ref: ../misc/image.v1.yaml
-            anyOf:
-              - required:
-                 - thumbnail
-              - required:
-                 - social
+            required:
+              - thumbnail


### PR DESCRIPTION
Although this is failing tests, the change to the required parameter needs to be only made to the schema where the social image is expected. 

The behaviour should be:

1. the `image` property is optional.
2. in article listings if the image property is present it should only be for `vor` and must include the `thumbnail` property.
3. for `poa` full articles if the `image` property is there it must contain the `social` property.
4. for `vor` full articles if the `image` property is there it must contain either the `thumbnail` or `social` property or both.

Before this change 1, 3 and 4 was true but 2 wasn't.

Because the test suite doesn't currently have examples of expected errors it is hard to demonstrate that all of these conditions are true.

cc @lsh-0, I will put some more time on this tomorrow. I am having the same issue with the `interview` content on this PR: https://github.com/elifesciences/api-raml/pull/256

cc @thewilkybarkid @giorgiosironi any pointers would be really appreciated.