### PR TITLE
Rename uri to scietyUri in editorEvaluation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.0
+
+### Changed
+
+* rename `uri` property to `scietyUri` in an `editorEvaluation`
+
 ## 2.4.0
 
 ### Changed

--- a/src/model/article-vor.v6.yaml
+++ b/src/model/article-vor.v6.yaml
@@ -77,7 +77,7 @@ allOf:
                     items:
                         $ref: ../misc/blocks-all.v2.yaml
                     minItems: 1
-                uri:
+                scietyUri:
                     title: Related material URI
                     type: string
                     format: uri

--- a/src/samples/article-vor/v6/complete.json
+++ b/src/samples/article-vor/v6/complete.json
@@ -1741,7 +1741,7 @@
                 "text": "Collagen is a major component of extracellular matrix. The authors have identified a high-affinity inhibitory collagen receptor LAIR-1 and a soluble decoy receptor LAIR-2 (with even higher binding affinity to collagen), which can be therapeutically targeted to block tumor progression. Dr Meyaard and colleagues have also generated a dimeric LAIR-2 human IgG1 Fc fusion protein NC410 for therapeutic use. With humanized mouse models engrafted with functional human immune systems (PBMC), they have explored the anti-cancer efficacy of NC410 and revealed its impact on modulating immune responses. Furthermore, they extended this study to identify biomarkers of predictive value for NC410-based anti-cancer therapy."
             }
         ],
-        "uri": "https://sciety.org/articles/activity/10.1101/2020.11.21.391326"
+        "scietyUri": "https://sciety.org/articles/activity/10.1101/2020.11.21.391326"
     },
     "decisionLetter": {
         "id": "SA1",

--- a/src/samples/article-vor/v6/unpublished-complete.json
+++ b/src/samples/article-vor/v6/unpublished-complete.json
@@ -1600,7 +1600,7 @@
                 "text": "Collagen is a major component of extracellular matrix. The authors have identified a high-affinity inhibitory collagen receptor LAIR-1 and a soluble decoy receptor LAIR-2 (with even higher binding affinity to collagen), which can be therapeutically targeted to block tumor progression. Dr Meyaard and colleagues have also generated a dimeric LAIR-2 human IgG1 Fc fusion protein NC410 for therapeutic use. With humanized mouse models engrafted with functional human immune systems (PBMC), they have explored the anti-cancer efficacy of NC410 and revealed its impact on modulating immune responses. Furthermore, they extended this study to identify biomarkers of predictive value for NC410-based anti-cancer therapy."
             }
         ],
-        "uri": "https://sciety.org/articles/activity/10.1101/2020.11.21.391326"
+        "scietyUri": "https://sciety.org/articles/activity/10.1101/2020.11.21.391326"
     },
     "decisionLetter": {
         "id": "SA1",


### PR DESCRIPTION
Replaces PR https://github.com/elifesciences/api-raml/pull/273

Re issue https://github.com/elifesciences/issues/issues/6940

For review and further discussion, if required, I think this is the simpler method to change an existing property to a new name, `uri` to `scietyUri`, without incrementing the `article-vor` version.

