### PR TITLE
deprecate article-vor v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changed
 
-* remove experimental flag from `application/vnd.elife.article-vor+json;version=7`
-* add deprecated flag to `application/vnd.elife.article-vor+json;version=6`
+* removed experimental flag from `application/vnd.elife.article-vor+json;version=7`
+* added deprecated flag to `application/vnd.elife.article-vor+json;version=6`
 
 ## 2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.16.0
+
+### Changed
+
+* remove experimental flag from `application/vnd.elife.article-vor+json;version=7`
+* add deprecated flag to `application/vnd.elife.article-vor+json;version=6`
+
 ## 2.15.0
 
 ### Added

--- a/src/api.raml
+++ b/src/api.raml
@@ -398,6 +398,7 @@ traits:
                                     displayName: PreviewComplete
                                     value: !include samples/article-poa/v3/unpublished-complete.json
                         application/vnd.elife.article-vor+json;version=6:
+                            (deprecated):
                             schema: !include model/article-vor.v6.json
                             examples:
                                 minimum:
@@ -428,7 +429,6 @@ traits:
                                     displayName: '15691'
                                     value: !include samples/article-vor/v6/15691.json
                         application/vnd.elife.article-vor+json;version=7:
-                            (experimental):
                             schema: !include model/article-vor.v7.json
                             examples:
                                 minimum:
@@ -593,6 +593,7 @@ traits:
                                             displayName: PreviewComplete
                                             value: !include samples/article-poa/v3/unpublished-complete.json
                                 application/vnd.elife.article-vor+json;version=6:
+                                    (deprecated):
                                     schema: !include ../dist/model/article-vor.v6.json
                                     examples:
                                         minimum:
@@ -623,7 +624,6 @@ traits:
                                             displayName: '15691'
                                             value: !include samples/article-vor/v6/15691.json
                                 application/vnd.elife.article-vor+json;version=7:
-                                    (experimental):
                                     schema: !include ../dist/model/article-vor.v7.json
                                     examples:
                                         minimum:


### PR DESCRIPTION
Now that vor v7 is live we should deprecate v6.