### PR TITLE
Add optional sentForReview date to article history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.17.0
+
+### Added
+
+* introduce optional `sentForReview` date to article history
+
 ## 2.16.0
 
 ### Changed

--- a/src/model/article-history.v2.yaml
+++ b/src/model/article-history.v2.yaml
@@ -8,6 +8,9 @@ properties:
     accepted:
         type: string
         format: date
+    sentForPeerReview:
+        type: string
+        format: date
     versions:
         description: List of article versions, sorted by version in descending order
         type: array

--- a/src/model/article-history.v2.yaml
+++ b/src/model/article-history.v2.yaml
@@ -8,7 +8,7 @@ properties:
     accepted:
         type: string
         format: date
-    sentForPeerReview:
+    sentForReview:
         type: string
         format: date
     versions:

--- a/src/samples/article-history/v2/prc.json
+++ b/src/samples/article-history/v2/prc.json
@@ -1,0 +1,68 @@
+{
+  "received": "2023-12-10T00:00:00Z",
+  "accepted": "2023-12-10T00:00:00Z",
+  "sentForPeerReview": "2023-03-15T00:00:00Z",
+  "versions": [
+      {
+          "status": "preprint",
+          "description": "This manuscript was published as a preprint.",
+          "uri": "https://doi.org/10.1101/2021.11.09.467796",
+          "date": "2023-02-15T00:00:00Z"
+      },
+      {
+          "status": "preprint",
+          "description": "This manuscript was published as a reviewed preprint.",
+          "uri": "https://doi.org/10.7554/eLife.1234567890.1",
+          "date": "2023-04-15T00:00:00Z"
+      },
+      {
+          "status": "preprint",
+          "description": "The reviewed preprint was revised.",
+          "uri": "https://doi.org/10.7554/eLife.1234567890.2",
+          "date": "2023-09-10T00:00:00Z"
+      },
+      {
+          "status": "preprint",
+          "description": "The reviewed preprint was revised.",
+          "uri": "https://doi.org/10.7554/eLife.1234567890.3",
+          "date": "2023-11-10T00:00:00Z"
+      },
+      {
+          "status": "vor",
+          "id": "1234567890",
+          "version": 1,
+          "type": "research-article",
+          "doi": "10.7554/eLife.1234567890",
+          "authorLine": "Frederick Peter Atherden III, Melissa Harrison ... Cornel West Jnr",
+          "title": "eLife kitchen sink 3.0",
+          "volume": 12,
+          "elocationId": "RP1234567890",
+          "pdf": "https://continuumtest-cdn.elifesciences.org/articles/1234567890/elife-1234567890-v1.pdf",
+          "figuresPdf": "https://continuumtest-cdn.elifesciences.org/articles/1234567890/elife-1234567890-figures-v1.pdf",
+          "subjects": [
+              {
+                  "id": "biochemistry-chemical-biology",
+                  "name": "Biochemistry and Chemical Biology"
+              },
+              {
+                  "id": "chromosomes-gene-expression",
+                  "name": "Chromosomes and Gene Expression"
+              }
+          ],
+          "researchOrganisms": [
+              "Human",
+              "Mouse"
+          ],
+          "copyright": {
+              "license": "CC-BY-4.0",
+              "holder": "Atherden et al.",
+              "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+          },
+          "impactStatement": "This is an impact statement <i>i</i><sup>a</sup><sub>b</sub>.",
+          "stage": "published",
+          "published": "2023-12-10T00:00:00Z",
+          "versionDate": "2023-12-10T00:00:00Z",
+          "statusDate": "2023-12-10T00:00:00Z"
+      }
+  ]
+}

--- a/src/samples/article-history/v2/prc.json
+++ b/src/samples/article-history/v2/prc.json
@@ -1,7 +1,7 @@
 {
   "received": "2023-12-10T00:00:00Z",
   "accepted": "2023-12-10T00:00:00Z",
-  "sentForPeerReview": "2023-03-15T00:00:00Z",
+  "sentForReview": "2023-03-15T00:00:00Z",
   "versions": [
       {
           "status": "preprint",

--- a/src/samples/article-history/v2/prc.json
+++ b/src/samples/article-history/v2/prc.json
@@ -1,7 +1,7 @@
 {
-  "received": "2023-12-10T00:00:00Z",
-  "accepted": "2023-12-10T00:00:00Z",
-  "sentForReview": "2023-03-15T00:00:00Z",
+  "received": "2023-12-10",
+  "accepted": "2023-12-10",
+  "sentForReview": "2023-03-15",
   "versions": [
       {
           "status": "preprint",


### PR DESCRIPTION
@fred-atherden this is what we discussed yesterday. If you could update this PR with direction of where to find the value in the XML.

I'm not precious about what we call the field name but unless a better name surfaces let's run with this one.#

cc @lsh-0 @gnott @smoqadam 