### PR TITLE
feat: Add support for reviewed preprints in promotional collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Changelog
 
+## 2.24.0
+
+### Added
+
+* added experimental support for reviewed preprints in `application/vnd.elife.promotional-collection+json;version=2`
+
 ## 2.23.0
 
 ### Added
 
 * added experimental support for reviewed preprints in `application/vnd.elife.collection+json;version=3`
-
 * added experimental support for reviewed preprints in `application/vnd.elife.article-related+json;version=2`
 
 ### Removed
 
 * removed support for `application/vnd.elife.collection+json;version=1`
-
 * removed experimental flag from `application/vnd.elife.collection+json;version=2`
 
 ## 2.22.0

--- a/src/api.raml
+++ b/src/api.raml
@@ -1743,6 +1743,15 @@ traits:
                                 complete:
                                     displayName: Complete
                                     value: !include samples/promotional-collection/v1/complete.json
+                        application/vnd.elife.promotional-collection+json;version=2:
+                            schema: !include ../dist/model/promotional-collection.v2.json
+                            examples:
+                                minimum:
+                                    displayName: Minimum
+                                    value: !include samples/promotional-collection/v2/minimum.json
+                                complete:
+                                    displayName: Complete
+                                    value: !include samples/promotional-collection/v2/complete.json
 
 /recommendations/{type}/{id}:
     type: collection

--- a/src/model/promotional-collection.v2.yaml
+++ b/src/model/promotional-collection.v2.yaml
@@ -1,0 +1,88 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Promotional collection
+type: object
+allOf:
+  - $ref: ../snippets/promotional-collection.v1.yaml
+  - properties:
+        image:
+            type: object
+            properties:
+                banner:
+                    $ref: ../misc/image.v1.yaml
+                social:
+                    $ref: ../misc/image.v1.yaml
+            required:
+              - banner
+        editors:
+            description: List of editors, ordered by name
+            type: array
+            items:
+                $ref: ../snippets/person.v1.yaml
+        summary:
+            title: Summary
+            type: array
+            items:
+                $ref: ../blocks/paragraph.v1.yaml
+        content:
+            title: Content
+            type: array
+            items:
+                oneOf:
+                  - $ref: ../snippets/article-poa.v1.yaml
+                  - $ref: ../snippets/article-vor.v1.yaml
+                  - allOf:
+                      - type: object
+                        required:
+                          - type
+                      - oneOf:
+                          - allOf:
+                              - properties:
+                                    type:
+                                        type: string
+                                        enum:
+                                          - blog-article
+                              - $ref: ../snippets/blog-article.v1.yaml
+                          - allOf:
+                              - properties:
+                                    type:
+                                        type: string
+                                        enum:
+                                          - digest
+                              - $ref: ../snippets/digest.v1.yaml
+                          - allOf:
+                              - properties:
+                                    type:
+                                        type: string
+                                        enum:
+                                          - event
+                              - $ref: ../snippets/event.v1.yaml
+                          - allOf:
+                              - properties:
+                                    type:
+                                        type: string
+                                        enum:
+                                          - interview
+                              - $ref: ../snippets/interview.v1.yaml
+                          - allOf:
+                              - properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - reviewed-preprint
+                              - $ref: ../snippets/reviewed-preprint.v1.yaml
+            minItems: 1
+            uniqueItems: true
+        relatedContent:
+            title: Related content
+            type: array
+            items:
+                $ref: '#/allOf/1/properties/content/items'
+            uniqueItems: true
+        podcastEpisodes:
+            title: Related podcast episodes
+            type: array
+            items:
+                $ref: ../snippets/podcast-episode.v1.yaml
+            uniqueItems: true
+    required:
+      - content

--- a/src/samples/promotional-collection/v2/complete.json
+++ b/src/samples/promotional-collection/v2/complete.json
@@ -1,6 +1,6 @@
 {
     "id": "1",
-    "title": "reviewed-preprint collection",
+    "title": "Highlights from Japan",
     "impactStatement": "eLife has published papers on many tropical diseases, including malaria, Ebola, leishmaniases, Dengue and African sleeping sickness.",
     "published": "2015-09-16T11:19:26Z",
     "updated": "2015-09-17T11:19:26Z",
@@ -67,19 +67,7 @@
             "name": "Microbiology and Infectious Disease"
         }
     ],
-    "selectedCurator": {
-        "id": "pjha",
-        "type": {
-            "id": "senior-editor",
-            "label": "Senior Editor"
-        },
-        "name": {
-            "preferred": "Prabhat Jha",
-            "index": "Jha, Prabhat"
-        },
-        "etAl": true
-    },
-    "curators": [
+    "editors": [
         {
             "id": "bcooper",
             "type": {
@@ -110,52 +98,6 @@
         }
     ],
     "content": [
-        {
-            "type": "reviewed-preprint",
-            "id": "19560",
-            "doi": "10.7554/eLife.19560",
-            "status": "reviewed",
-            "authorLine": "Lee R Berger, John Hawks ... Scott A Williams",
-            "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
-            "titlePrefix": "Title prefix",
-            "stage": "published",
-            "published": "2022-08-01T00:00:00Z",
-            "reviewedDate": "2022-08-01T00:00:00Z",
-            "versionDate": "2022-08-05T00:00:00Z",
-            "statusDate": "2022-08-01T00:00:00Z",
-            "volume": 4,
-            "elocationId": "e19560",
-            "pdf": "https://elifesciences.org/content/4/e19560.pdf",
-            "subjects": [
-                {
-                    "id": "genomics-evolutionary-biology",
-                    "name": "Genomics and Evolutionary Biology"
-                }
-            ],
-            "curationLabels": [
-                "Ground-breaking",
-                "Convincing"
-            ],
-            "image": {
-                "thumbnail": {
-                    "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif",
-                    "alt": "",
-                    "source": {
-                        "mediaType": "image/jpeg",
-                        "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif/full/full/0/default.jpg",
-                        "filename": "an-image.jpg"
-                    },
-                    "size": {
-                        "width": 4194,
-                        "height": 4714
-                    },
-                    "focalPoint": {
-                        "x": 25,
-                        "y": 75
-                    }
-                }
-            }
-        },
         {
             "type": "research-article",
             "status": "vor",
@@ -243,6 +185,53 @@
         }
     ],
     "relatedContent": [
+        {
+            "type": "reviewed-preprint",
+            "id": "19560",
+            "doi": "10.7554/eLife.19560",
+            "status": "reviewed",
+            "authorLine": "Lee R Berger, John Hawks ... Scott A Williams",
+            "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
+            "indexContent": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
+            "titlePrefix": "Title prefix",
+            "stage": "published",
+            "published": "2022-08-01T00:00:00Z",
+            "reviewedDate": "2022-08-01T00:00:00Z",
+            "versionDate": "2022-08-05T00:00:00Z",
+            "statusDate": "2022-08-01T00:00:00Z",
+            "volume": 4,
+            "elocationId": "e19560",
+            "pdf": "https://elifesciences.org/content/4/e19560.pdf",
+            "subjects": [
+                {
+                    "id": "genomics-evolutionary-biology",
+                    "name": "Genomics and Evolutionary Biology"
+                }
+            ],
+            "curationLabels": [
+                "Ground-breaking",
+                "Convincing"
+            ],
+            "image": {
+                "thumbnail": {
+                    "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif",
+                    "alt": "",
+                    "source": {
+                        "mediaType": "image/jpeg",
+                        "uri": "https://iiif.elifesciences.org/lax/19560%2Felife-19560-fig1-v1.tif/full/full/0/default.jpg",
+                        "filename": "an-image.jpg"
+                    },
+                    "size": {
+                        "width": 4194,
+                        "height": 4714
+                    },
+                    "focalPoint": {
+                        "x": 25,
+                        "y": 75
+                    }
+                }
+            }
+        },
         {
             "type": "research-article",
             "status": "poa",

--- a/src/samples/promotional-collection/v2/minimum.json
+++ b/src/samples/promotional-collection/v2/minimum.json
@@ -1,0 +1,52 @@
+{
+    "id": "1",
+    "title": "Highlights from Japan",
+    "published": "2015-09-16T11:19:26Z",
+    "image": {
+        "banner": {
+            "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif",
+            "alt": "",
+            "attribution": [
+                "By some person."
+            ],
+            "source": {
+                "mediaType": "image/jpeg",
+                "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif/full/full/0/default.jpg",
+                "filename": "an-image.jpg"
+            },
+            "size": {
+                "width": 4194,
+                "height": 4714
+            }
+        },
+        "thumbnail": {
+            "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif",
+            "alt": "",
+            "source": {
+                "mediaType": "image/jpeg",
+                "uri": "https://iiif.elifesciences.org/lax/09560%2Felife-09560-fig1-v1.tif/full/full/0/default.jpg",
+                "filename": "an-image.jpg"
+            },
+            "size": {
+                "width": 4194,
+                "height": 4714
+            }
+        }
+    },
+    "content": [
+        {
+            "type": "research-article",
+            "status": "poa",
+            "id": "14107",
+            "version": 1,
+            "doi": "10.7554/eLife.14107",
+            "authorLine": "Yongjian Huang et al.",
+            "title": "Molecular basis for multimerization in the activation of the epidermal growth factor",
+            "stage": "published",
+            "published": "2016-03-28T00:00:00Z",
+            "statusDate": "2016-03-28T00:00:00Z",
+            "volume": 5,
+            "elocationId": "e14107"
+        }
+    ]
+}


### PR DESCRIPTION
This update introduces support for reviewed preprints in `application/vnd.elife.promotional-collection+json;version=2`. It also includes the addition of a new schema file `promotional-collection.v2.yaml` and new sample files for promotional collections. Additionally, some redundant content in the `complete.json` file under `src/samples/collection/v3` has been removed.