### PR TITLE
Add specificUse field to data reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@
 
 * added `specificUse` to references of type `data` in `misc/reference.v2.yaml`
 
-### Changed
-
-* changed `id` URI parameter in `/articles/{id}` from `string` to `integer`.
-    - zero padded integers are still integers and are fine.
-
 ## 2.30.0
 
 ### Added
 
 * added optional version to reviewed-preprint
+
+### Changed
+
+* changed `id` URI parameter in `/articles/{id}` from `string` to `integer`.
+    - zero padded integers are still integers and are fine.
 
 ## 2.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## 2.29.0
+
+### Added
+
+* added `specificUse` to references of type `data` in `misc/reference.v2.yaml`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@
 
 * added optional version to reviewed-preprint
 
-### Changed
-
-* changed `id` URI parameter in `/articles/{id}` from `string` to `integer`.
-    - zero padded integers are still integers and are fine.
-
 ## 2.29.0
 
 ### Added
@@ -24,6 +19,11 @@
 * for `Expression of Concern` article type, added `expression-concern` to list of allowed `type` values in `snippets/article.v1.yaml`
 * `expression-concern` to list of `types` in `model/search.v2.yaml`
 * added `expression-concern` to `api.raml`
+
+### Changed
+
+* changed `id` URI parameter in `/articles/{id}` from `string` to `integer`.
+    - zero padded integers are still integers and are fine.
 
 ### Fixed
 

--- a/src/misc/reference.v2.yaml
+++ b/src/misc/reference.v2.yaml
@@ -174,6 +174,11 @@ allOf:
                     minLength: 1
                 assigningAuthority:
                     $ref: place.v1.yaml
+                specificUse:
+                    type: string
+                    enum:
+                      - analyzed
+                      - generated
                 doi:
                     $ref: doi.v1.yaml
                 uri:

--- a/src/samples/article-vor/v8/complete.json
+++ b/src/samples/article-vor/v8/complete.json
@@ -1091,6 +1091,7 @@
                     }
                 }
             },
+            "specificUse": "analyzed",
             "doi": "10.2210/pdb4qen/pdb",
             "uri": "https://doi.org/10.2210/pdb4qen/pdb"
         },

--- a/src/samples/article-vor/v8/unpublished-complete.json
+++ b/src/samples/article-vor/v8/unpublished-complete.json
@@ -974,6 +974,7 @@
                     }
                 }
             },
+            "specificUse": "analyzed",
             "doi": "10.2210/pdb4qen/pdb",
             "uri": "https://doi.org/10.2210/pdb4qen/pdb"
         },


### PR DESCRIPTION
Proposed changes to add `specificUse` to references of type `data`, its value can be either `analyzed` or `generated`.

Based on early discussion about how if we add a new optional field we do not need to bump the version numbers.

I promoted the `[unreleased]` notes in the changelog to be a proposed version `2.29.0` release.