### PR TITLE
Add expression-concern article type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## 2.29.0
+
+### Added
+
+* for `Expression of Concern` article type, added `expression-concern` to list of allowed `type` values in `snippets/article.v1.yaml`
+* `expression-concern` to list of `types` in `model/search.v2.yaml`
+* added `expression-concern` to `api.raml`
 
 ### Changed
 

--- a/src/api.raml
+++ b/src/api.raml
@@ -1887,6 +1887,7 @@ traits:
                     enum:
                       - correction
                       - editorial
+                      - expression-concern
                       - feature
                       - insight
                       - research-advance

--- a/src/model/search.v2.yaml
+++ b/src/model/search.v2.yaml
@@ -89,6 +89,10 @@ properties:
         description: Number of editorial articles in the result set
         type: integer
         minimum: 0
+      expression-concern:
+        description: Number of expression of concern articles in the result set
+        type: integer
+        minimum: 0
       feature:
         description: Number of feature articles in the result set
         type: integer
@@ -164,6 +168,7 @@ properties:
     required:
       - correction
       - editorial
+      - expression-concern
       - feature
       - insight
       - research-advance

--- a/src/samples/search/v2/empty.json
+++ b/src/samples/search/v2/empty.json
@@ -5,6 +5,7 @@
     "types": {
         "correction": 0,
         "editorial": 0,
+        "expression-concern": 0,
         "feature": 0,
         "insight": 0,
         "research-advance": 0,

--- a/src/samples/search/v2/first-page.json
+++ b/src/samples/search/v2/first-page.json
@@ -278,6 +278,7 @@
     "types": {
         "correction": 0,
         "editorial": 1,
+        "expression-concern": 0,
         "feature": 0,
         "insight": 0,
         "research-advance": 1,

--- a/src/snippets/article.v1.yaml
+++ b/src/snippets/article.v1.yaml
@@ -12,6 +12,7 @@ properties:
         enum:
           - correction
           - editorial
+          - expression-concern
           - feature
           - insight
           - research-advance


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8869, part of epic issue https://github.com/elifesciences/issues/issues/8856

The type value does not include the `of` in `Expression of Concern`, similar to how `Tools and Resources` uses the type value `tools-resources` in the API.