### PR TITLE
Propose version to be a required property for a reviewed preprint

### DIFF
--- a/src/snippets/reviewed-preprint.v1.yaml
+++ b/src/snippets/reviewed-preprint.v1.yaml
@@ -88,3 +88,4 @@ required:
     - id
     - title
     - stage
+    - version


### PR DESCRIPTION
We have been working on [homepage listings](https://github.com/elifesciences/enhanced-preprints-issues/issues/1014) which displays some teasers of reviewed preprints.

We have noticed that the schema allows for a `reviewed-preprint` to not have a `version`, however we have not found examples in the production data by browsing the website and a couple of pages of the API.

We were wondering if this could be made mandatory, unless there are cases where a reviewed-preprint is allowed not to have a version. The behavior of `journal` if this case happens is benign (does not explode) but otherwise undefined.

# Prerequites

- [ ] include `version` in all samples in `api-dummy`
- [ ] include `version` in all samples in `journal`
- [ ] make `version` mandatory in [`api-sdk-php`](https://github.com/elifesciences/api-sdk-php/blob/master/src/Model/ReviewedPreprint.php#L56)
- [ ] update samples in this PR