### PR TITLE
Add citation metrics by version DOI endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.33.0
+
+### Added
+
+* added endpoint for citation metrics by verison DOI to `api.raml` (`metrics/{type}/{id}/citations/version/{version}`)
+
 ## 2.32.0
 
 ### Added

--- a/src/api.raml
+++ b/src/api.raml
@@ -1362,6 +1362,26 @@ traits:
                         schema: !include ../dist/model/metric-citations.v1.json
                         example:
                             value: !include samples/metric-citations/v1/complete.json
+    /version/{version}:
+        type: collection
+        description: |
+            Version citation metrics
+        uriParameters:
+            version:
+                description: |
+                    Article version number.
+                type: integer
+                minimum: 1
+        get:
+            description: |
+                Get citation metrics for an article version
+            responses:
+                200:
+                    body:
+                        application/vnd.elife.metric-citations+json;version=1:
+                            schema: !include ../dist/model/metric-citations.v1.json
+                            example:
+                                value: !include samples/metric-citations/v1/complete.json
 
 /metrics/{type}/{id}/{metric}:
     type: collection


### PR DESCRIPTION
Based on my initial composition of how the schema may be modified to mirror the metrics API URL pattern, this matches with proposed changes to the `api-sdk-php` library. I may have missed something here and all feedback is welcome! Please invite more reviewers as you see fit.

Re issue https://github.com/elifesciences/enhanced-preprints-issues/issues/1053